### PR TITLE
Ensure LLM summaries clear fallback details

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -530,7 +530,10 @@ async def interpret_rows(rows: list[ParsedRowIn]) -> tuple[InterpretationOut, di
         # No JSON required: treat LLM output as plain text summary
         text_out = (raw or "").strip()
         base = _fallback_interpretation(rows)
-        parsed = base.model_copy(update={"summary": text_out or base.summary})
+        if text_out:
+            parsed = base.model_copy(update={"summary": text_out, "per_test": [], "next_steps": []})
+        else:
+            parsed = base
         meta["ok"] = True
         if call:
             if "usage" in call:


### PR DESCRIPTION
## Summary
- update the LLM interpretation success path to overwrite the fallback summary while clearing per-test and next-steps content when text is returned
- add a regression test that stubs the OpenAI call and verifies the summary echo and empty collections

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ca19424e28832a8968f41bb7126d2f