### PR TITLE
Respect configured OpenAI model defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
       PYTHONUNBUFFERED: "1"
       OPENAI_API_KEY: ${OPENAI_API_KEY}
-      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-5}
+      OPENAI_MODEL: ${OPENAI_MODEL:-o4-mini}
       OPENAI_API_BASE: ${OPENAI_API_BASE:-https://api.openai.com/v1}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
       OPENAI_REASONING_EFFORT: ${OPENAI_REASONING_EFFORT:-high}


### PR DESCRIPTION
## Summary
- allow the OpenAI client helpers to honor configured model names and only fall back to gpt-5 when unset
- default docker-compose OPENAI_MODEL to o4-mini and gate Responses API usage on gpt-5 unless explicitly overridden

## Testing
- cd backend && pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68ca29b98dc8832a946d6b7c3c1ef786