### PR TITLE
Longitudinal trend analysis - FR12

### DIFF
--- a/backend/app/routers/parse.py
+++ b/backend/app/routers/parse.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel
 
 from app.services.ocr import extract_text_from_image_bytes, extract_text_from_pdf_bytes
-from app.services.parser import parse_text
+from app.services.parser import extract_report_date, parse_text
 
 router = APIRouter()
 
@@ -117,7 +117,9 @@ async def parse_endpoint(
             raise HTTPException(status_code=400, detail="Body must include 'text'.")
         text_content = str(payload.get("text") or "")
 
-    rows, unparsed = parse_text(text_content or "")
+    source_text = text_content or ""
+    rows, unparsed = parse_text(source_text)
+    observed_at = extract_report_date(source_text)
     # Convert dataclasses to dicts
     payload_rows = []
     for i, r in enumerate(rows, start=1):
@@ -144,6 +146,8 @@ async def parse_endpoint(
         "rows": payload_rows,
         "unparsed_lines": unparsed,
         "unparsed": [{"page": None, "text": s} for s in unparsed],
-        "meta": {},
-        "extracted_text": text_content or "",
+        "meta": {
+            "report_date": observed_at.isoformat() if observed_at else None,
+        },
+        "extracted_text": source_text,
     }

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -21,6 +21,7 @@ from app.db.models import (
 from app.db.session import get_db_session
 from app.dependencies.auth import AuthContext, get_current_auth_context
 from app.dependencies.reports import get_accessible_report
+from app.services.trends import BiomarkerTrend, build_trends_for_patient
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -80,6 +81,29 @@ class ReportOut(BaseModel):
 
 class ReportDetailResponse(BaseModel):
     report: ReportOut
+
+
+class TrendPointOut(BaseModel):
+    report_id: str
+    observed_at: datetime
+    value: float
+    unit: str | None
+    flag: str
+
+
+class BiomarkerTrendOut(BaseModel):
+    biomarker_key: str
+    display_name: str
+    unit: str | None
+    direction: str
+    trend_note: str
+    sparkline: list[TrendPointOut]
+
+
+class ReportTrendsResponse(BaseModel):
+    report_id: str
+    subject_user_id: str
+    trends: list[BiomarkerTrendOut]
 
 
 @router.get("", response_model=list[ReportOut])
@@ -275,3 +299,71 @@ def _report_out(report: Report) -> ReportOut:
 @router.get("/{report_id}", response_model=ReportDetailResponse)
 async def get_report_endpoint(report: Report = Depends(get_accessible_report)) -> ReportDetailResponse:
     return ReportDetailResponse(report=_report_out(report))
+
+
+async def _ensure_full_report_trend_access(
+    *,
+    report: Report,
+    auth: AuthContext,
+    session: AsyncSession,
+) -> None:
+    if report.subject_user_id == auth.user.id:
+        return
+
+    now = datetime.now(UTC)
+    full_access_share = await session.scalar(
+        select(ConsentShare.id)
+        .where(
+            ConsentShare.subject_user_id == report.subject_user_id,
+            ConsentShare.grantee_user_id == auth.user.id,
+            ConsentShare.scope == ConsentScope.PATIENT,
+            ConsentShare.report_id.is_(None),
+            ConsentShare.revoked_at.is_(None),
+            ConsentShare.expires_at > now,
+        )
+        .limit(1)
+    )
+    if full_access_share is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Trend data requires full-report access for this patient",
+        )
+
+
+def _trend_out(trend: BiomarkerTrend) -> BiomarkerTrendOut:
+    return BiomarkerTrendOut(
+        biomarker_key=trend.biomarker_key,
+        display_name=trend.display_name,
+        unit=trend.unit,
+        direction=trend.direction,
+        trend_note=trend.trend_note,
+        sparkline=[
+            TrendPointOut(
+                report_id=point.report_id,
+                observed_at=point.observed_at,
+                value=point.value,
+                unit=point.unit,
+                flag=point.flag.value,
+            )
+            for point in trend.points
+        ],
+    )
+
+
+@router.get("/{report_id}/trends", response_model=ReportTrendsResponse)
+async def get_report_trends_endpoint(
+    report: Report = Depends(get_accessible_report),
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> ReportTrendsResponse:
+    await _ensure_full_report_trend_access(report=report, auth=auth, session=session)
+
+    trends = await build_trends_for_patient(
+        session,
+        subject_user_id=report.subject_user_id,
+    )
+    return ReportTrendsResponse(
+        report_id=report.id,
+        subject_user_id=report.subject_user_id,
+        trends=[_trend_out(item) for item in trends],
+    )

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -76,6 +76,7 @@ class ReportOut(BaseModel):
     title: str | None
     source_kind: str
     sharing_mode: str
+    created_at: datetime
     observed_at: datetime
     findings: list[ReportFindingOut]
 
@@ -292,6 +293,7 @@ def _report_out(report: Report) -> ReportOut:
         title=report.title,
         source_kind=report.source_kind.value,
         sharing_mode=report.sharing_mode.value,
+        created_at=report.created_at,
         observed_at=report.observed_at,
         findings=[_finding_out(finding) for finding in findings],
     )

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -46,6 +46,7 @@ class ReportCreateFinding(BaseModel):
 class ReportCreateRequest(BaseModel):
     title: str | None = None
     source_kind: ReportSourceKind = ReportSourceKind.MANUAL
+    observed_at: datetime | None = None
     findings: list[ReportCreateFinding] = []
 
 
@@ -133,7 +134,7 @@ async def create_report(
         title=payload.title,
         source_kind=payload.source_kind,
         sharing_mode=ReportSharingMode.PRIVATE,
-        observed_at=datetime.now(UTC),
+        observed_at=payload.observed_at or datetime.now(UTC),
     )
     session.add(report)
     await session.flush()

--- a/backend/app/routers/translate.py
+++ b/backend/app/routers/translate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
@@ -24,6 +25,7 @@ SUPPORTED_LANGUAGES: dict[str, str] = {
 class TranslateRequest(BaseModel):
     text: str
     target_language: str
+    prefetch_all: bool = False
 
 
 @router.post("/translate")
@@ -39,6 +41,109 @@ async def translate_endpoint(payload: TranslateRequest) -> Any:
         raise HTTPException(status_code=400, detail="unsupported target_language")
 
     label = SUPPORTED_LANGUAGES[code]
+    if payload.prefetch_all:
+        async def _translate(code_item: str, label_item: str):
+            translation_item, meta_item = await llm_service.translate_summary(
+                text,
+                target_language=code_item,
+                language_label=label_item,
+            )
+            return code_item, translation_item, meta_item
+
+        translate_targets = [
+            (lang_code, lang_label)
+            for lang_code, lang_label in SUPPORTED_LANGUAGES.items()
+            if lang_code != "en"
+        ]
+        results = await asyncio.gather(
+            *[_translate(lang_code, lang_label) for lang_code, lang_label in translate_targets],
+            return_exceptions=False,
+        )
+
+        translations: dict[str, str] = {}
+        per_language_meta: dict[str, Any] = {}
+        requested_translation: str | None = None
+        requested_meta: dict[str, Any] = {}
+        for lang_code, translated_text, translated_meta in results:
+            per_language_meta[lang_code] = {
+                key: translated_meta.get(key)
+                for key in [
+                    "duration_ms",
+                    "llm",
+                    "attempts",
+                    "ok",
+                    "model",
+                    "endpoint",
+                    "status",
+                    "usage",
+                    "finish_reason",
+                    "error",
+                    "language",
+                ]
+                if key in translated_meta
+            }
+            if translated_text:
+                translations[lang_code] = translated_text
+            if lang_code == code:
+                requested_translation = translated_text
+                requested_meta = translated_meta
+
+        if requested_translation is None:
+            err = (requested_meta or {}).get("error", {}) or {}
+            error_code = str(err.get("code") or "")
+            safe_requested_meta = {
+                key: requested_meta[key]
+                for key in [
+                    "duration_ms",
+                    "llm",
+                    "attempts",
+                    "ok",
+                    "model",
+                    "endpoint",
+                    "status",
+                    "usage",
+                    "finish_reason",
+                    "error",
+                    "language",
+                ]
+                if key in requested_meta
+            }
+            if error_code in {"missing_api_key", "missing_openai_dependency"}:
+                return JSONResponse(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    content={"detail": "Translation service unavailable", "meta": safe_requested_meta},
+                )
+            return JSONResponse(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                content={"detail": "Translation failed", "meta": safe_requested_meta},
+            )
+
+        return {
+            "language": code,
+            "translation": requested_translation,
+            "translations": translations,
+            "meta": {
+                "requested": {
+                    key: requested_meta[key]
+                    for key in [
+                        "duration_ms",
+                        "llm",
+                        "attempts",
+                        "ok",
+                        "model",
+                        "endpoint",
+                        "status",
+                        "usage",
+                        "finish_reason",
+                        "error",
+                        "language",
+                    ]
+                    if key in requested_meta
+                },
+                "prefetch": per_language_meta,
+            },
+        }
+
     translation, meta = await llm_service.translate_summary(
         text,
         target_language=code,

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -496,38 +496,8 @@ async def interpret_rows(rows: list[ParsedRowIn]) -> tuple[InterpretationOut, di
                 meta["finish_reason"] = call["finish_reason"]
             if "status" in call:
                 meta["status"] = call["status"]
-        summary_text = parsed.summary.strip()
-        translations: dict[str, str] = {}
-        translation_meta: dict[str, Any] = {}
-        api_key_present = bool(os.getenv("OPENAI_API_KEY", "").strip())
-        if summary_text and api_key_present and TRANSLATION_TARGETS:
-            async def _translate(code: str, label: str) -> tuple[str, str | None, dict[str, Any] | None]:
-                try:
-                    text, tmeta = await translate_summary(summary_text, target_language=code, language_label=label)
-                    return code, text, tmeta
-                except Exception as exc:  # pragma: no cover - defensive
-                    return code, None, {"ok": False, "error": {"message": str(exc)}}
-
-            tasks = [_translate(code, label) for code, label in TRANSLATION_TARGETS.items()]
-            results = await asyncio.gather(*tasks, return_exceptions=False)
-            for code, text, tmeta in results:
-                if tmeta:
-                    translation_meta[code] = {
-                        k: tmeta.get(k)
-                        for k in ("ok", "status", "error", "duration_ms")
-                        if k in tmeta
-                    }
-                if text:
-                    translations[code] = text
-            if translations:
-                parsed = parsed.model_copy(update={"translations": translations})
-                meta["translations"] = sorted(translations.keys())
-        else:
-            if not api_key_present:
-                meta["translations"] = []
-                meta.setdefault("translation_meta", {})["skipped"] = "missing_api_key"
-        if translation_meta:
-            meta.setdefault("translation_meta", {}).update(translation_meta)
+        meta["translations"] = []
+        meta.setdefault("translation_meta", {})["skipped"] = "lazy_on_demand"
         _log_ok = {
             "event": "llm_call",
             "endpoint": meta.get("endpoint"),

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 # Precompiled regexes for performance
 # Number pattern supporting either plain digits, or thousands groups, with optional decimal using '.' or ','.
@@ -60,6 +61,77 @@ ONLY_COMPARATOR = re.compile(rf"^\(?\s*(?:≤|>=|≥|<=|<|>)\s*{NUM}\s*\)?\s*$")
 BARE_PAREN = re.compile(r"^\(\s*\)?$")
 JUNK_NAME = re.compile(r"^[\s()\[\]{}·•≤≥<>]+$")
 HYPHEN_LINE = re.compile(r"^[-_·•.,\s]+$")
+
+DATE_CANDIDATE = re.compile(
+    r"(?P<date>\d{4}[/-]\d{1,2}[/-]\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{1,2}\s+[A-Za-z]{3,9}\s+\d{2,4}|[A-Za-z]{3,9}\s+\d{1,2},?\s+\d{2,4})"
+)
+
+REPORT_DATE_PRIMARY_PATTERNS = [
+    re.compile(r"\b(?:report(?:ed)?\s*date|result\s*date|test\s*date|observation\s*date)\b[^\n:]*[:\-]?\s*(?P<date>.+)$", re.IGNORECASE),
+]
+
+REPORT_DATE_SECONDARY_PATTERNS = [
+    re.compile(r"\b(?:collection\s*date|collected(?:\s*on)?|specimen\s*collected|sample\s*collected)\b[^\n:]*[:\-]?\s*(?P<date>.+)$", re.IGNORECASE),
+]
+
+
+def _parse_date_candidate(value: str) -> datetime | None:
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"\b(\d{1,2})(st|nd|rd|th)\b", r"\1", cleaned, flags=re.IGNORECASE)
+
+    formats = [
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%d/%m/%Y",
+        "%d/%m/%y",
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%d-%m-%Y",
+        "%d-%m-%y",
+        "%m-%d-%Y",
+        "%m-%d-%y",
+        "%d %b %Y",
+        "%d %B %Y",
+        "%b %d %Y",
+        "%B %d %Y",
+        "%b %d, %Y",
+        "%B %d, %Y",
+    ]
+
+    for fmt in formats:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+            return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
+
+
+def extract_report_date(text: str) -> datetime | None:
+    lines = [line.strip() for line in text.splitlines()]
+
+    for patterns in (REPORT_DATE_PRIMARY_PATTERNS, REPORT_DATE_SECONDARY_PATTERNS):
+        for line in lines:
+            if not line:
+                continue
+            if re.search(r"\bdob\b", line, re.IGNORECASE):
+                continue
+
+            for pattern in patterns:
+                match = pattern.search(line)
+                if not match:
+                    continue
+                segment = match.group("date") or ""
+                candidate_match = DATE_CANDIDATE.search(segment)
+                if not candidate_match:
+                    continue
+                parsed = _parse_date_candidate(candidate_match.group("date"))
+                if parsed is not None:
+                    return parsed
+
+    return None
 
 
 def _normalize_number_str(s: str) -> str:

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -77,6 +77,22 @@ def _distance_to_reference(value: float, low: float | None, high: float | None) 
     return value - high
 
 
+def _pick_best_finding(findings: list[tuple[ReportFinding, Report]]) -> tuple[ReportFinding, Report]:
+    """From multiple findings for the same (report, biomarker), pick the most clinically relevant one.
+
+    Priority: highest flag severity → largest distance from reference range → latest position.
+    """
+
+    def sort_key(item: tuple[ReportFinding, Report]) -> tuple[int, float, int]:
+        finding, _ = item
+        severity = _flag_severity(finding.flag)
+        numeric_value = float(finding.value_numeric) if finding.value_numeric is not None else 0.0
+        distance = _distance_to_reference(numeric_value, finding.reference_low, finding.reference_high)
+        return (severity, distance or 0.0, finding.position)
+
+    return max(findings, key=sort_key)
+
+
 def _classify_direction(previous: TrendPoint, current: TrendPoint) -> str:
     previous_severity = _flag_severity(previous.flag)
     current_severity = _flag_severity(current.flag)
@@ -141,7 +157,16 @@ async def build_trends_for_patient(
 
     trends: list[BiomarkerTrend] = []
     for biomarker_key, entries in grouped.items():
-        if len(entries) < 2:
+        # Collapse to one finding per report, picking the most clinically relevant
+        by_report: dict[str, list[tuple[ReportFinding, Report]]] = {}
+        for finding, report in entries:
+            by_report.setdefault(report.id, []).append((finding, report))
+        deduped = [_pick_best_finding(items) for items in by_report.values()]
+        deduped.sort(
+            key=lambda item: (item[1].observed_at, item[1].created_at, item[0].position)
+        )
+
+        if len(deduped) < 2:
             continue
 
         points = [
@@ -154,12 +179,12 @@ async def build_trends_for_patient(
                 reference_low=finding.reference_low,
                 reference_high=finding.reference_high,
             )
-            for finding, report in entries
+            for finding, report in deduped
         ]
         previous, current = points[-2], points[-1]
         direction = _classify_direction(previous, current)
 
-        latest_finding = entries[-1][0]
+        latest_finding = deduped[-1][0]
         trends.append(
             BiomarkerTrend(
                 biomarker_key=biomarker_key,

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -9,6 +9,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.models import FindingFlag, Report, ReportFinding
 
 
+NON_QUANTITATIVE_MARKER_NAME = {
+    "date",
+    "report date",
+    "collection date",
+    "collected date",
+    "observation date",
+    "sample date",
+    "specimen date",
+    "reported date",
+    "dob",
+    "birth date",
+}
+
+
 @dataclass(frozen=True)
 class TrendPoint:
     report_id: str
@@ -32,6 +46,17 @@ class BiomarkerTrend:
 
 def _normalize_biomarker_key(value: str | None) -> str:
     return (value or "").strip().lower()
+
+
+def _is_quantitative_finding(finding: ReportFinding) -> bool:
+    if finding.value_numeric is None:
+        return False
+
+    name = _normalize_biomarker_key(finding.display_name or finding.biomarker_key)
+    if not name:
+        return False
+
+    return name not in NON_QUANTITATIVE_MARKER_NAME
 
 
 def _flag_severity(flag: FindingFlag) -> int:
@@ -107,7 +132,7 @@ async def build_trends_for_patient(
 
     grouped: dict[str, list[tuple[ReportFinding, Report]]] = {}
     for finding, report in rows.all():
-        if finding.value_numeric is None:
+        if not _is_quantitative_finding(finding):
             continue
         biomarker_key = _normalize_biomarker_key(finding.biomarker_key or finding.display_name)
         if not biomarker_key:

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import FindingFlag, Report, ReportFinding
+
+
+@dataclass(frozen=True)
+class TrendPoint:
+    report_id: str
+    observed_at: datetime
+    value: float
+    unit: str | None
+    flag: FindingFlag
+    reference_low: float | None
+    reference_high: float | None
+
+
+@dataclass(frozen=True)
+class BiomarkerTrend:
+    biomarker_key: str
+    display_name: str
+    unit: str | None
+    direction: str
+    trend_note: str
+    points: list[TrendPoint]
+
+
+def _normalize_biomarker_key(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _flag_severity(flag: FindingFlag) -> int:
+    if flag is FindingFlag.NORMAL:
+        return 0
+    if flag is FindingFlag.UNKNOWN:
+        return 1
+    return 2
+
+
+def _distance_to_reference(value: float, low: float | None, high: float | None) -> float | None:
+    if low is None or high is None:
+        return None
+    if low <= value <= high:
+        return 0.0
+    if value < low:
+        return low - value
+    return value - high
+
+
+def _classify_direction(previous: TrendPoint, current: TrendPoint) -> str:
+    previous_severity = _flag_severity(previous.flag)
+    current_severity = _flag_severity(current.flag)
+    if current_severity < previous_severity:
+        return "improving"
+    if current_severity > previous_severity:
+        return "worsening"
+
+    delta = current.value - previous.value
+    baseline = abs(previous.value)
+    relative_delta = abs(delta) / baseline if baseline > 0 else abs(delta)
+    if relative_delta <= 0.03:
+        return "stable"
+
+    previous_distance = _distance_to_reference(previous.value, previous.reference_low, previous.reference_high)
+    current_distance = _distance_to_reference(current.value, current.reference_low, current.reference_high)
+    if previous_distance is not None and current_distance is not None:
+        if current_distance + 1e-9 < previous_distance:
+            return "improving"
+        if current_distance > previous_distance + 1e-9:
+            return "worsening"
+        return "stable"
+
+    if current.flag is FindingFlag.HIGH:
+        return "improving" if delta < 0 else "worsening"
+    if current.flag is FindingFlag.LOW:
+        return "improving" if delta > 0 else "worsening"
+    if current.flag in {FindingFlag.ABNORMAL, FindingFlag.UNKNOWN, FindingFlag.NORMAL}:
+        return "worsening" if relative_delta > 0.1 else "stable"
+
+    return "stable"
+
+
+def _build_trend_note(display_name: str, direction: str) -> str:
+    if direction == "improving":
+        return f"{display_name} trend appears to be improving compared with prior reports."
+    if direction == "worsening":
+        return f"{display_name} trend appears to be worsening compared with prior reports."
+    return f"{display_name} trend appears stable across recent reports."
+
+
+async def build_trends_for_patient(
+    session: AsyncSession,
+    *,
+    subject_user_id: str,
+) -> list[BiomarkerTrend]:
+    rows = await session.execute(
+        select(ReportFinding, Report)
+        .join(Report, Report.id == ReportFinding.report_id)
+        .where(Report.subject_user_id == subject_user_id)
+        .order_by(Report.observed_at.asc(), Report.created_at.asc(), ReportFinding.position.asc())
+    )
+
+    grouped: dict[str, list[tuple[ReportFinding, Report]]] = {}
+    for finding, report in rows.all():
+        if finding.value_numeric is None:
+            continue
+        biomarker_key = _normalize_biomarker_key(finding.biomarker_key or finding.display_name)
+        if not biomarker_key:
+            continue
+        grouped.setdefault(biomarker_key, []).append((finding, report))
+
+    trends: list[BiomarkerTrend] = []
+    for biomarker_key, entries in grouped.items():
+        if len(entries) < 2:
+            continue
+
+        points = [
+            TrendPoint(
+                report_id=report.id,
+                observed_at=report.observed_at,
+                value=float(finding.value_numeric),
+                unit=finding.unit,
+                flag=finding.flag,
+                reference_low=finding.reference_low,
+                reference_high=finding.reference_high,
+            )
+            for finding, report in entries
+        ]
+        previous, current = points[-2], points[-1]
+        direction = _classify_direction(previous, current)
+
+        latest_finding = entries[-1][0]
+        trends.append(
+            BiomarkerTrend(
+                biomarker_key=biomarker_key,
+                display_name=latest_finding.display_name,
+                unit=latest_finding.unit,
+                direction=direction,
+                trend_note=_build_trend_note(latest_finding.display_name, direction),
+                points=points,
+            )
+        )
+
+    trends.sort(key=lambda item: item.display_name.lower())
+    return trends

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import selectinload, sessionmaker
 
 from app.db.base import Base
-from app.db.models import AuthSession, Report, User, UserRole
+from app.db.models import AuditEvent, AuthSession, ConsentShare, Report, User, UserRole
 from app.main import create_app
 from app.services.auth import hash_password, verify_password
 from passlib.context import CryptContext
@@ -149,6 +149,49 @@ def expire_latest_session(session_factory: sessionmaker, *, email: str) -> None:
         assert auth_session is not None
         auth_session.expires_at = datetime.now(UTC) - timedelta(minutes=1)
         session.commit()
+
+
+def expire_share_for_grantee(
+    session_factory: sessionmaker,
+    *,
+    patient_email: str,
+    grantee_email: str,
+    report_id: str,
+) -> None:
+    with session_factory() as session:
+        patient = session.scalar(select(User).where(User.email == patient_email))
+        grantee = session.scalar(select(User).where(User.email == grantee_email))
+        assert patient is not None
+        assert grantee is not None
+        share = session.scalar(
+            select(ConsentShare).where(
+                ConsentShare.subject_user_id == patient.id,
+                ConsentShare.grantee_user_id == grantee.id,
+                ConsentShare.report_id == report_id,
+                ConsentShare.revoked_at.is_(None),
+            )
+        )
+        assert share is not None
+        share.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        session.commit()
+
+
+def audit_actions_for_resource(
+    session_factory: sessionmaker,
+    *,
+    resource_type: str,
+    resource_id: str,
+) -> list[str]:
+    with session_factory() as session:
+        events = session.scalars(
+            select(AuditEvent)
+            .where(
+                AuditEvent.resource_type == resource_type,
+                AuditEvent.resource_id == resource_id,
+            )
+            .order_by(AuditEvent.occurred_at.asc())
+        ).all()
+        return [event.action for event in events]
 
 
 @pytest.mark.parametrize(
@@ -430,6 +473,148 @@ def test_patient_can_share_report_via_api(auth_api: AuthApiHarness):
         headers=auth_headers(clinician_login["access_token"]),
     )
     assert allowed.status_code == 200
+
+
+def test_share_requires_recipient_scope_and_expiry(auth_api: AuthApiHarness):
+    register_user(
+        auth_api,
+        email="patient.share.required@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Required Fields",
+    )
+    register_user(
+        auth_api,
+        email="clinician.share.required@example.com",
+        password="Password123!",
+        role="clinician",
+        display_name="Clinician Required Fields",
+    )
+    report_id = create_report_for_users(
+        auth_api.session_factory,
+        subject_email="patient.share.required@example.com",
+        created_by_email="patient.share.required@example.com",
+    )
+    patient_login = login_user(auth_api, email="patient.share.required@example.com", password="Password123!")
+
+    missing_scope = auth_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": "clinician.share.required@example.com",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=2)).isoformat(),
+        },
+    )
+    assert missing_scope.status_code == 422
+
+    missing_expiry = auth_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": "clinician.share.required@example.com",
+            "scope": "report",
+            "access_level": "read",
+        },
+    )
+    assert missing_expiry.status_code == 422
+
+
+def test_share_view_revoke_and_expiry_create_audit_records(auth_api: AuthApiHarness):
+    patient_email = "patient.audit@example.com"
+    clinician_email = "clinician.audit@example.com"
+    register_user(
+        auth_api,
+        email=patient_email,
+        password="Password123!",
+        role="patient",
+        display_name="Patient Audit",
+    )
+    register_user(
+        auth_api,
+        email=clinician_email,
+        password="Password123!",
+        role="clinician",
+        display_name="Clinician Audit",
+    )
+
+    report_id = create_report_for_users(
+        auth_api.session_factory,
+        subject_email=patient_email,
+        created_by_email=patient_email,
+    )
+
+    patient_login = login_user(auth_api, email=patient_email, password="Password123!")
+    share_response = auth_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=7)).isoformat(),
+        },
+    )
+    assert share_response.status_code == 201, share_response.text
+
+    clinician_login = login_user(auth_api, email=clinician_email, password="Password123!")
+    allowed = auth_api.client.get(
+        f"/api/v1/reports/{report_id}",
+        headers=auth_headers(clinician_login["access_token"]),
+    )
+    assert allowed.status_code == 200
+
+    revoke = auth_api.client.post(
+        f"/api/v1/reports/{report_id}/share/revoke",
+        headers=auth_headers(patient_login["access_token"]),
+        json={"clinician_email": clinician_email},
+    )
+    assert revoke.status_code == 204
+
+    denied_after_revoke = auth_api.client.get(
+        f"/api/v1/reports/{report_id}",
+        headers=auth_headers(clinician_login["access_token"]),
+    )
+    assert denied_after_revoke.status_code == 403
+    assert "revoked" in denied_after_revoke.json()["detail"].lower()
+
+    # Re-share, force expiry, then verify expiry denial with audit trail.
+    reshared = auth_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+    assert reshared.status_code == 201
+
+    expire_share_for_grantee(
+        auth_api.session_factory,
+        patient_email=patient_email,
+        grantee_email=clinician_email,
+        report_id=report_id,
+    )
+
+    denied_after_expiry = auth_api.client.get(
+        f"/api/v1/reports/{report_id}",
+        headers=auth_headers(clinician_login["access_token"]),
+    )
+    assert denied_after_expiry.status_code == 403
+    assert "expired" in denied_after_expiry.json()["detail"].lower()
+
+    actions = audit_actions_for_resource(
+        auth_api.session_factory,
+        resource_type="report",
+        resource_id=report_id,
+    )
+    assert "share.granted" in actions
+    assert "report.viewed" in actions
+    assert "share.revoked" in actions
+    assert "share.access_denied.revoked" in actions
+    assert "share.access_denied.expired" in actions
 
 
 def test_logout_revokes_the_session_and_expired_sessions_are_rejected(auth_api: AuthApiHarness):

--- a/backend/tests/test_interpret.py
+++ b/backend/tests/test_interpret.py
@@ -79,13 +79,9 @@ def test_interpret_rows_prefers_llm_summary(monkeypatch):
     async def good_call(prompt: str, timeout_s: float) -> tuple[str, dict[str, Any]]:  # type: ignore[override]
         return "Stub summary from LLM", {"usage": {"total_tokens": 42}}
 
-    async def fake_translate(text: str, *, target_language: str, language_label: str):  # type: ignore[override]
-        return f"Translation {target_language}", {"ok": True}
-
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.setenv("OPENAI_USE_RESPONSES", "1")
     monkeypatch.setattr(llm_module, "_call_openai_responses", good_call)
-    monkeypatch.setattr(llm_module, "translate_summary", fake_translate)
 
     result, meta = asyncio.run(llm_module.interpret_rows(rows))
 
@@ -95,4 +91,5 @@ def test_interpret_rows_prefers_llm_summary(monkeypatch):
     assert result.next_steps == []
     assert result.flags == base.flags
     assert result.disclaimer == base.disclaimer
-    assert result.translations.get("es") == "Translation es"
+    assert result.translations == {}
+    assert meta.get("translation_meta", {}).get("skipped") == "lazy_on_demand"

--- a/backend/tests/test_parser_text.py
+++ b/backend/tests/test_parser_text.py
@@ -1,4 +1,4 @@
-from app.services.parser import parse_text
+from app.services.parser import extract_report_date, parse_text
 
 
 def test_parse_numeric_range_and_units():
@@ -44,3 +44,32 @@ def test_confidence_scoring():
     row = rows[0]
     # test_name, value, unit, reference_range, flag => often all present
     assert 0.8 <= row.confidence <= 1.0
+
+
+def test_extract_report_date_prefers_report_date_field():
+    text = """
+    Patient: Jane Doe
+    Collection Date: 03/03/2026
+    Report Date: 05/03/2026
+    ALT 29 U/L 10-40
+    """.strip()
+
+    parsed = extract_report_date(text)
+    assert parsed is not None
+    assert parsed.year == 2026
+    assert parsed.month == 3
+    assert parsed.day == 5
+
+
+def test_extract_report_date_ignores_dob_and_uses_collection_when_needed():
+    text = """
+    DOB: 05/01/1990
+    Specimen Collected: 2026-04-01
+    AST 31 U/L 10-40
+    """.strip()
+
+    parsed = extract_report_date(text)
+    assert parsed is not None
+    assert parsed.year == 2026
+    assert parsed.month == 4
+    assert parsed.day == 1

--- a/backend/tests/test_trends_api.py
+++ b/backend/tests/test_trends_api.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+from app.db.models import User
+from app.main import create_app
+from tests.factories import PersistenceFactory
+
+
+@dataclass
+class TrendsApiHarness:
+    client: TestClient
+    session_factory: sessionmaker
+
+
+@pytest.fixture()
+def trends_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TrendsApiHarness:
+    db_path = tmp_path / "trends-api.sqlite3"
+    sync_database_url = f"sqlite:///{db_path.resolve().as_posix()}"
+    async_database_url = f"sqlite+aiosqlite:///{db_path.resolve().as_posix()}"
+
+    monkeypatch.setenv("DATABASE_URL", async_database_url)
+    monkeypatch.setenv("AUTH_SECRET_KEY", "reportx-test-auth-secret-key-with-32-bytes")
+    monkeypatch.setenv("ACCESS_TOKEN_TTL_MINUTES", "15")
+    monkeypatch.setenv("REFRESH_SESSION_TTL_DAYS", "30")
+
+    engine = create_engine(sync_database_url, future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+    Base.metadata.create_all(engine)
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+        async def wait(self):
+            return None
+
+        def kill(self):
+            return None
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield TrendsApiHarness(client=client, session_factory=session_factory)
+
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+
+
+def auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def register_user(
+    trends_api: TrendsApiHarness,
+    *,
+    email: str,
+    password: str,
+    role: str,
+    display_name: str,
+) -> dict:
+    response = trends_api.client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": password,
+            "role": role,
+            "display_name": display_name,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def login_user(trends_api: TrendsApiHarness, *, email: str, password: str) -> dict:
+    response = trends_api.client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def create_report_with_findings(
+    session_factory: sessionmaker,
+    *,
+    subject_email: str,
+    created_by_email: str,
+    observed_at: datetime,
+    hemoglobin_value: float,
+    hemoglobin_flag: str,
+    include_singleton_biomarker: bool = False,
+) -> str:
+    with session_factory() as session:
+        factory = PersistenceFactory(session)
+        subject = session.scalar(select(User).where(User.email == subject_email))
+        created_by = session.scalar(select(User).where(User.email == created_by_email))
+        assert subject is not None
+        assert created_by is not None
+
+        report = factory.create_report(
+            subject=subject,
+            created_by=created_by,
+            observed_at=observed_at,
+        )
+        factory.create_finding(
+            report=report,
+            patient=subject,
+            biomarker_key="hemoglobin",
+            display_name="Hemoglobin",
+            value_numeric=hemoglobin_value,
+            unit="g/dL",
+            flag=hemoglobin_flag,
+            reference_low=12.0,
+            reference_high=15.5,
+        )
+        if include_singleton_biomarker:
+            factory.create_finding(
+                report=report,
+                patient=subject,
+                biomarker_key="single-marker",
+                display_name="Single Marker",
+                value_numeric=3.0,
+                unit="mg/L",
+                flag="normal",
+                reference_low=1.0,
+                reference_high=5.0,
+            )
+
+        session.commit()
+        return report.id
+
+
+def test_patient_trends_return_series_and_skip_singletons(trends_api: TrendsApiHarness):
+    register_user(
+        trends_api,
+        email="patient.trends@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Trends",
+    )
+
+    older_report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.trends@example.com",
+        created_by_email="patient.trends@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=14),
+        hemoglobin_value=17.2,
+        hemoglobin_flag="high",
+    )
+    newer_report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.trends@example.com",
+        created_by_email="patient.trends@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=2),
+        hemoglobin_value=14.0,
+        hemoglobin_flag="normal",
+        include_singleton_biomarker=True,
+    )
+
+    login = login_user(trends_api, email="patient.trends@example.com", password="Password123!")
+    response = trends_api.client.get(
+        f"/api/v1/reports/{newer_report_id}/trends",
+        headers=auth_headers(login["access_token"]),
+    )
+    assert response.status_code == 200, response.text
+
+    payload = response.json()
+    assert payload["report_id"] == newer_report_id
+    assert payload["trends"]
+    assert len(payload["trends"]) == 1
+
+    hemoglobin = payload["trends"][0]
+    assert hemoglobin["biomarker_key"] == "hemoglobin"
+    assert hemoglobin["direction"] == "improving"
+    assert "improving" in hemoglobin["trend_note"].lower()
+    assert len(hemoglobin["sparkline"]) == 2
+    assert hemoglobin["sparkline"][0]["report_id"] == older_report_id
+    assert hemoglobin["sparkline"][1]["report_id"] == newer_report_id
+
+
+def test_single_report_returns_empty_trends(trends_api: TrendsApiHarness):
+    register_user(
+        trends_api,
+        email="patient.single@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Single",
+    )
+
+    report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.single@example.com",
+        created_by_email="patient.single@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=3),
+        hemoglobin_value=13.4,
+        hemoglobin_flag="normal",
+    )
+
+    login = login_user(trends_api, email="patient.single@example.com", password="Password123!")
+    response = trends_api.client.get(
+        f"/api/v1/reports/{report_id}/trends",
+        headers=auth_headers(login["access_token"]),
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["trends"] == []
+
+
+def test_clinician_trends_require_full_report_access(trends_api: TrendsApiHarness):
+    register_user(
+        trends_api,
+        email="patient.access@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Access",
+    )
+    register_user(
+        trends_api,
+        email="clinician.access@example.com",
+        password="Password123!",
+        role="clinician",
+        display_name="Clinician Access",
+    )
+
+    report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.access@example.com",
+        created_by_email="patient.access@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=7),
+        hemoglobin_value=16.1,
+        hemoglobin_flag="high",
+    )
+    create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.access@example.com",
+        created_by_email="patient.access@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=1),
+        hemoglobin_value=14.6,
+        hemoglobin_flag="normal",
+    )
+
+    patient_login = login_user(trends_api, email="patient.access@example.com", password="Password123!")
+    report_scope_share = trends_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": "clinician.access@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=3)).isoformat(),
+        },
+    )
+    assert report_scope_share.status_code == 201, report_scope_share.text
+
+    clinician_login = login_user(trends_api, email="clinician.access@example.com", password="Password123!")
+    denied = trends_api.client.get(
+        f"/api/v1/reports/{report_id}/trends",
+        headers=auth_headers(clinician_login["access_token"]),
+    )
+    assert denied.status_code == 403
+    assert "full-report access" in denied.json()["detail"].lower()
+
+    patient_scope_share = trends_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_login["access_token"]),
+        json={
+            "clinician_email": "clinician.access@example.com",
+            "scope": "patient",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=3)).isoformat(),
+        },
+    )
+    assert patient_scope_share.status_code == 201, patient_scope_share.text
+
+    allowed = trends_api.client.get(
+        f"/api/v1/reports/{report_id}/trends",
+        headers=auth_headers(clinician_login["access_token"]),
+    )
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.json()["trends"]

--- a/backend/tests/test_trends_api.py
+++ b/backend/tests/test_trends_api.py
@@ -106,6 +106,7 @@ def create_report_with_findings(
     hemoglobin_value: float,
     hemoglobin_flag: str,
     include_singleton_biomarker: bool = False,
+    include_report_date_numeric_finding: bool = False,
 ) -> str:
     with session_factory() as session:
         factory = PersistenceFactory(session)
@@ -141,6 +142,17 @@ def create_report_with_findings(
                 flag="normal",
                 reference_low=1.0,
                 reference_high=5.0,
+            )
+
+        if include_report_date_numeric_finding:
+            factory.create_finding(
+                report=report,
+                patient=subject,
+                biomarker_key="report-date",
+                display_name="Report Date",
+                value_numeric=float(observed_at.strftime("%Y%m%d")),
+                unit=None,
+                flag="normal",
             )
 
         session.commit()
@@ -220,6 +232,46 @@ def test_single_report_returns_empty_trends(trends_api: TrendsApiHarness):
     )
     assert response.status_code == 200, response.text
     assert response.json()["trends"] == []
+
+
+def test_trends_exclude_date_like_numeric_findings(trends_api: TrendsApiHarness):
+    register_user(
+        trends_api,
+        email="patient.numericfilter@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Numeric Filter",
+    )
+
+    create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.numericfilter@example.com",
+        created_by_email="patient.numericfilter@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=10),
+        hemoglobin_value=15.8,
+        hemoglobin_flag="high",
+        include_report_date_numeric_finding=True,
+    )
+    newer_report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.numericfilter@example.com",
+        created_by_email="patient.numericfilter@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=1),
+        hemoglobin_value=14.3,
+        hemoglobin_flag="normal",
+        include_report_date_numeric_finding=True,
+    )
+
+    login = login_user(trends_api, email="patient.numericfilter@example.com", password="Password123!")
+    response = trends_api.client.get(
+        f"/api/v1/reports/{newer_report_id}/trends",
+        headers=auth_headers(login["access_token"]),
+    )
+    assert response.status_code == 200, response.text
+
+    trend_names = {item["display_name"] for item in response.json()["trends"]}
+    assert "Hemoglobin" in trend_names
+    assert "Report Date" not in trend_names
 
 
 def test_clinician_trends_require_full_report_access(trends_api: TrendsApiHarness):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,13 @@
       "name": "reportrx-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "chartjs-plugin-annotation": "^3.1.0",
+        "date-fns": "^4.1.0",
         "next": "14.2.5",
         "react": "18.3.1",
+        "react-chartjs-2": "^5.3.1",
         "react-dom": "18.3.1"
       },
       "devDependencies": {
@@ -338,6 +343,11 @@
       "version": "1.5.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@next/env": {
       "version": "14.2.5",
@@ -1766,6 +1776,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/chartjs-plugin-annotation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
+      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
+      "peerDependencies": {
+        "chart.js": ">=4.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "dev": true,
@@ -1921,6 +1959,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4736,6 +4783,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -187,6 +187,108 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
       "cpu": [
@@ -197,6 +299,312 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -348,6 +756,19 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
     },
     "node_modules/@next/env": {
       "version": "14.2.5",
@@ -1000,6 +1421,17 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
@@ -1180,6 +1612,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
       "cpu": [
@@ -1190,6 +1650,257 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@vitest/expect": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-plugin-annotation": "^3.1.0",
+    "date-fns": "^4.1.0",
     "next": "14.2.5",
     "react": "18.3.1",
+    "react-chartjs-2": "^5.3.1",
     "react-dom": "18.3.1"
   },
   "devDependencies": {

--- a/frontend/src/app/auth/__tests__/AuthFlow.test.tsx
+++ b/frontend/src/app/auth/__tests__/AuthFlow.test.tsx
@@ -40,7 +40,7 @@ function TestProtectedPage() {
 }
 
 describe('Auth flow', () => {
-  let fetchSpy: ReturnType<typeof vi.fn>;
+  let fetchSpy: any;
 
   beforeEach(() => {
     localStorage.clear();

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -271,9 +271,237 @@ input:focus-visible, textarea:focus-visible {
   padding: 1rem;
 }
 
+.history-summary {
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.report-history-table-card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.report-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: none;
+}
+
+.report-history-table thead tr {
+  height: 40px;
+  background: #f9fafb;
+}
+
+.report-history-table th {
+  padding: 0 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: left;
+  border: none;
+}
+
+.report-history-sort {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: inherit;
+  color: inherit;
+}
+
+.report-history-table tbody tr {
+  height: 52px;
+  font-size: 14px;
+  color: #111827;
+}
+
+.report-history-table tbody tr:nth-child(odd) {
+  background: #ffffff;
+}
+
+.report-history-table tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+
+.report-history-table tbody tr:hover {
+  background: #f0fdfa;
+}
+
+.report-history-table tbody tr:first-child td {
+  border-top: 1px solid #f0f0f0;
+}
+
+.report-history-table td {
+  padding: 0 16px;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: middle;
+}
+
+.report-history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.report-history-table .date-col {
+  font-weight: 500;
+}
+
+.report-history-table .results-col {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.report-history-table .actions-col {
+  text-align: right;
+  padding-right: 12px;
+}
+
+.report-date-fallback {
+  color: #6b7280;
+}
+
+.help-icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  color: #6b7280;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.muted-cell {
+  color: #6b7280;
+}
+
+.interp-pill {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.interp-pill.yes {
+  background: #ccfbf1;
+  color: #0f766e;
+}
+
+.interp-pill.no {
+  background: #e5e7eb;
+  color: #6b7280;
+}
+
+.table-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.table-btn {
+  height: 32px;
+  border-radius: 6px;
+  font-size: 13px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  min-width: 72px;
+  line-height: 1;
+}
+
+.table-btn-primary {
+  background: var(--brand);
+  color: #ffffff;
+}
+
+.table-btn-ghost {
+  background: transparent;
+  border-color: #d1d5db;
+  color: #374151;
+}
+
+.empty-row td {
+  height: 80px;
+  text-align: center;
+  font-size: 14px;
+  color: #9ca3af;
+  border-bottom: none;
+}
+
+.report-history-mobile-list {
+  display: none;
+}
+
+.mobile-report-row {
+  padding: 10px 12px 12px;
+  border-bottom: 1px solid #f3f4f6;
+  background: #ffffff;
+}
+
+.mobile-line-1,
+.mobile-line-2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mobile-line-2 {
+  margin-top: 8px;
+}
+
+.mobile-date-panel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mobile-date {
+  font-weight: 600;
+  color: #111827;
+  font-size: 14px;
+}
+
+.mobile-panel {
+  font-size: 13px;
+  color: #111827;
+}
+
+.mobile-empty {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
 @media (max-width: 640px) {
   .biomarker-timeline-shell {
     height: 220px;
+  }
+
+  .report-history-table {
+    display: none;
+  }
+
+  .report-history-mobile-list {
+    display: block;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -196,6 +196,87 @@ input:focus-visible, textarea:focus-visible {
   /* Show full content; allow natural height */
 }
 
+/* Biomarker timeline chart */
+.biomarker-timeline-card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+  border: 1px solid var(--border);
+}
+
+.biomarker-timeline-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.biomarker-timeline-filter {
+  max-width: 420px;
+}
+
+.biomarker-timeline-filter input {
+  width: 100%;
+}
+
+.biomarker-timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.biomarker-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  background: #ffffff;
+  color: var(--ink);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.biomarker-pill:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.biomarker-pill.is-inactive {
+  opacity: 0.5;
+}
+
+.biomarker-pill__swatch {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.biomarker-timeline-shell {
+  height: 320px;
+  position: relative;
+}
+
+.biomarker-timeline-empty {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+  padding: 1rem;
+}
+
+@media (max-width: 640px) {
+  .biomarker-timeline-shell {
+    height: 220px;
+  }
+}
+
 /* Header + layout */
 .header {
   background: linear-gradient(180deg, rgba(8,152,160,.12), transparent);

--- a/frontend/src/app/parse/__tests__/ParseFlow.test.tsx
+++ b/frontend/src/app/parse/__tests__/ParseFlow.test.tsx
@@ -40,9 +40,22 @@ describe('Parse + Interpret flow', () => {
               flags: [],
               next_steps: ['See your doctor.'],
               disclaimer: 'Educational only.',
-              translations: {
-                es: 'Resumen en español.',
-              },
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.includes('/api/v1/translate')) {
+        return new Response(
+          JSON.stringify({
+            language: 'es',
+            translation: 'Resumen en español.',
+            translations: {
+              es: 'Resumen en español.',
+              ar: 'ملخص باللغة العربية.',
+              zh: '中文总结。',
+              hi: 'हिंदी सारांश।',
+              fr: 'Résumé en français.',
             },
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } }
@@ -102,7 +115,9 @@ describe('Parse + Interpret flow', () => {
     // Change the translate dropdown to Español and wait for translation
     const select = screen.getByLabelText(/translate summary/i);
     fireEvent.change(select, { target: { value: 'es' } });
-    expect(screen.getByText(/Resumen en español\./i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Resumen en español\./i)).toBeInTheDocument();
+    });
   });
 
   it('invokes updateReportInHistory after explain', async () => {

--- a/frontend/src/app/parse/page.tsx
+++ b/frontend/src/app/parse/page.tsx
@@ -621,6 +621,12 @@ function ThinkingCard() {
 function SummaryCard({ summary, translations }: { summary: string; translations?: Record<string, string> }) {
   const [copied, setCopied] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<string>('en');
+  const [translationError, setTranslationError] = useState<string | null>(null);
+  const [loadingTranslations, setLoadingTranslations] = useState(false);
+  const [prefetchedAll, setPrefetchedAll] = useState(false);
+  const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+
+  const [dynamicTranslations, setDynamicTranslations] = useState<Record<string, string>>({});
 
   const normalizedTranslations = useMemo(() => {
     const next: Record<string, string> = { en: summary };
@@ -629,19 +635,54 @@ function SummaryCard({ summary, translations }: { summary: string; translations?
         next[code] = text.trim();
       }
     });
+    Object.entries(dynamicTranslations).forEach(([code, text]) => {
+      if (typeof text === 'string' && text.trim()) {
+        next[code] = text.trim();
+      }
+    });
     return next;
-  }, [summary, translations]);
-
-  const availableOptions = useMemo(() => {
-    return LANGUAGE_OPTIONS.filter(opt => Boolean(normalizedTranslations[opt.value]));
-  }, [normalizedTranslations]);
+  }, [summary, translations, dynamicTranslations]);
 
   useEffect(() => {
-    if (!availableOptions.find(opt => opt.value === selectedLanguage)) {
-      setSelectedLanguage('en');
-    }
+    setDynamicTranslations({});
+    setPrefetchedAll(false);
+    setSelectedLanguage('en');
+    setTranslationError(null);
     setCopied(false);
-  }, [availableOptions, selectedLanguage, summary]);
+  }, [summary]);
+
+  const fetchTranslationsIfNeeded = async (languageCode: string) => {
+    if (languageCode === 'en' || prefetchedAll) return;
+    if (normalizedTranslations[languageCode]) return;
+
+    setLoadingTranslations(true);
+    setTranslationError(null);
+    try {
+      const response = await fetch(`${backend}/api/v1/translate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: summary,
+          target_language: languageCode,
+          prefetch_all: true,
+        }),
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(`Translation failed: ${response.status} ${errorText}`);
+      }
+
+      const payload = await response.json();
+      const received = (payload?.translations ?? {}) as Record<string, string>;
+      setDynamicTranslations((prev) => ({ ...prev, ...received }));
+      setPrefetchedAll(true);
+    } catch (err: any) {
+      setTranslationError(err?.message || 'Translation failed.');
+      setSelectedLanguage('en');
+    } finally {
+      setLoadingTranslations(false);
+    }
+  };
 
   const tryParse = (value: string): string | null => {
     const trimmed = (value || '').trim();
@@ -689,14 +730,20 @@ function SummaryCard({ summary, translations }: { summary: string; translations?
           aria-label="Translate summary"
           className="summary-translate-select"
           value={selectedLanguage}
-          onChange={(e) => setSelectedLanguage(e.target.value)}
+          onChange={(e) => {
+            const languageCode = e.target.value;
+            setSelectedLanguage(languageCode);
+            void fetchTranslationsIfNeeded(languageCode);
+          }}
         >
-          {availableOptions.map(opt => (
+          {LANGUAGE_OPTIONS.map(opt => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
           ))}
         </select>
         <button className="btn btn-outline btn-sm" onClick={onCopy}>{copied ? 'Copied' : 'Copy'}</button>
       </div>
+      {loadingTranslations && <p>Loading translation…</p>}
+      {translationError && <p>{translationError}</p>}
       {isCodeBlock ? (
         <pre className="summary-code">{displayText}</pre>
       ) : (

--- a/frontend/src/app/parse/page.tsx
+++ b/frontend/src/app/parse/page.tsx
@@ -141,16 +141,18 @@ export default function ParsePage() {
         e.userMessage = true;
         throw e;
       }
-      const data = (await res.json()) as { rows: Row[]; unparsed_lines: string[]; extracted_text?: string };
+      const data = (await res.json()) as { rows: Row[]; unparsed_lines: string[]; extracted_text?: string; meta?: { report_date?: string | null } };
       setRows(data.rows);
       setUnparsed(data.unparsed_lines);
       setExtractedText(data.extracted_text || '');
+      const extractedReportDate = data.meta?.report_date ? new Date(data.meta.report_date).getTime() : undefined;
 
       if (user) {
         try {
           const reportEntry = await createReportEntry({
             title: `Report ${new Date().toLocaleString()}`,
             source_kind: 'text',
+            observed_at: data.meta?.report_date ?? undefined,
             findings: data.rows.map((row) => ({
               test_name: row.test_name,
               value_numeric: typeof row.value === 'number' ? row.value : undefined,
@@ -168,6 +170,7 @@ export default function ParsePage() {
             addReportToHistory({
               patientEmail: user.email,
               title: `Report ${new Date().toLocaleString()}`,
+              reportDate: extractedReportDate,
               rows: data.rows,
               unparsed: data.unparsed_lines,
               extractedText: data.extracted_text || '',
@@ -179,6 +182,7 @@ export default function ParsePage() {
           addReportToHistory({
             patientEmail: user.email,
             title: `Report ${new Date().toLocaleString()}`,
+            reportDate: extractedReportDate,
             rows: data.rows,
             unparsed: data.unparsed_lines,
             extractedText: data.extracted_text || '',
@@ -188,6 +192,7 @@ export default function ParsePage() {
         addReportToHistory({
           patientEmail: 'anonymous',
           title: `Report ${new Date().toLocaleString()}`,
+          reportDate: extractedReportDate,
           rows: data.rows,
           unparsed: data.unparsed_lines,
           extractedText: data.extracted_text || '',

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@/store/authStore';
 import { ProtectedView } from '@/components/ProtectedView';
 import { fetchReportById, updateReportInHistory } from '@/lib/reportHistory';
 import type { ReportHistoryEntry, SharingPreferences } from '@/lib/reportHistory';
+import Disclaimer from '@/components/Disclaimer';
+import { BiomarkerTrendChart } from '@/components/BiomarkerTrendChart';
+import { fetchReportTrends, type BiomarkerTrend } from '@/lib/reportTrends';
 
 function formatDate(ts: number) {
   return new Date(ts).toLocaleString();
@@ -17,11 +20,30 @@ const defaultSharingPreferences: SharingPreferences = {
   active: false,
 };
 
+const LANGUAGE_OPTIONS = [
+  { value: 'en', label: 'English' },
+  { value: 'es', label: 'Español' },
+  { value: 'ar', label: 'العربية' },
+  { value: 'zh', label: '中文 (普通话)' },
+  { value: 'hi', label: 'हिन्दी' },
+  { value: 'fr', label: 'Français' },
+];
+
 export default function ReportDetailPage({ params }: { params: { reportId: string } }) {
   const { user } = useAuth();
   const [report, setReport] = useState<ReportHistoryEntry | undefined>(undefined);
   const [sharingPreferences, setSharingPreferences] = useState<SharingPreferences>(defaultSharingPreferences);
   const [statusMessage, setStatusMessage] = useState('');
+  const [trends, setTrends] = useState<BiomarkerTrend[]>([]);
+  const [trendsLoading, setTrendsLoading] = useState(false);
+  const [trendsError, setTrendsError] = useState<string | null>(null);
+  const [trendLanguage, setTrendLanguage] = useState('en');
+  const [loadingTrendTranslations, setLoadingTrendTranslations] = useState(false);
+  const [trendTranslationError, setTrendTranslationError] = useState<string | null>(null);
+  const [trendNoteTranslations, setTrendNoteTranslations] = useState<Record<string, Record<string, string>>>({});
+  const [prefetchedTrendLanguages, setPrefetchedTrendLanguages] = useState<Record<string, boolean>>({});
+  const [biomarkerFilterText, setBiomarkerFilterText] = useState('');
+  const [selectedBiomarkerKey, setSelectedBiomarkerKey] = useState('');
 
   useEffect(() => {
     async function loadReport() {
@@ -52,27 +74,119 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
     setSharingPreferences(report.sharingPreferences ?? defaultSharingPreferences);
   }, [report]);
 
-  if (!user) {
-    return (
-      <ProtectedView>
-        <div>Loading...</div>
-      </ProtectedView>
-    );
-  }
-
-  if (!report) {
-    return (
-      <ProtectedView>
-        <section className="stack">
-          <h1>Report Not Found</h1>
-          <p>This report does not exist or you do not have permission to view it.</p>
-          {statusMessage && <div className="alert alert-error" style={{ marginTop: '1rem' }}>{statusMessage}</div>}
-        </section>
-      </ProtectedView>
-    );
-  }
+  useEffect(() => {
+    setTrends([]);
+    setTrendsError(null);
+    setTrendLanguage('en');
+    setTrendTranslationError(null);
+    setTrendNoteTranslations({});
+    setPrefetchedTrendLanguages({});
+    setBiomarkerFilterText('');
+    setSelectedBiomarkerKey('');
+  }, [report?.id]);
 
   const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+
+  function getAccessToken() {
+    const stored = localStorage.getItem('reportx_session');
+    if (!stored) return null;
+    try {
+      const session = JSON.parse(stored);
+      return session?.accessToken || null;
+    } catch {
+      return null;
+    }
+  }
+
+  const loadTrends = useCallback(async (reportId: string) => {
+    setTrendsLoading(true);
+    setTrendsError(null);
+    try {
+      const data = await fetchReportTrends(reportId);
+      setTrends(Array.isArray(data.trends) ? data.trends : []);
+    } catch (err: any) {
+      const message = String(err?.message || 'Unable to load trends.');
+      if (message.includes('403')) {
+        setTrendsError('Trend details require full-report sharing access for clinician views.');
+      } else {
+        setTrendsError('Unable to load trends right now.');
+      }
+      setTrends([]);
+    } finally {
+      setTrendsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!report?.id) return;
+    void loadTrends(report.id);
+  }, [report?.id, loadTrends]);
+
+  const translateTrendNotesIfNeeded = useCallback(async (languageCode: string) => {
+    if (languageCode === 'en' || trends.length === 0) return;
+
+    const withEnoughPoints = trends.filter((item) => item.sparkline.length > 1);
+    const toTranslate = withEnoughPoints.filter(
+      (item) => !trendNoteTranslations[item.biomarker_key]?.[languageCode] && !prefetchedTrendLanguages[item.biomarker_key],
+    );
+
+    if (toTranslate.length === 0) return;
+
+    setLoadingTrendTranslations(true);
+    setTrendTranslationError(null);
+
+    try {
+      const translated = await Promise.all(
+        toTranslate.map(async (item) => {
+          const response = await fetch(`${backend}/api/v1/translate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              text: item.trend_note,
+              target_language: languageCode,
+              prefetch_all: true,
+            }),
+          });
+
+          if (!response.ok) {
+            throw new Error('Trend note translation failed.');
+          }
+
+          const payload = await response.json();
+          const translations = (payload?.translations ?? {}) as Record<string, string>;
+          return { biomarkerKey: item.biomarker_key, translations };
+        }),
+      );
+
+      setTrendNoteTranslations((prev) => {
+        const next = { ...prev };
+        for (const item of translated) {
+          next[item.biomarkerKey] = {
+            ...(next[item.biomarkerKey] || {}),
+            ...item.translations,
+          };
+        }
+        return next;
+      });
+
+      setPrefetchedTrendLanguages((prev) => {
+        const next = { ...prev };
+        for (const item of translated) {
+          next[item.biomarkerKey] = true;
+        }
+        return next;
+      });
+    } catch {
+      setTrendTranslationError('Unable to translate trend notes right now. Showing English.');
+      setTrendLanguage('en');
+    } finally {
+      setLoadingTrendTranslations(false);
+    }
+  }, [backend, prefetchedTrendLanguages, trendNoteTranslations, trends]);
+
+  useEffect(() => {
+    void translateTrendNotesIfNeeded(trendLanguage);
+  }, [trendLanguage, translateTrendNotesIfNeeded]);
 
   async function updateShare() {
     if (!report) return;
@@ -81,16 +195,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
       return;
     }
 
-    const accessToken = (() => {
-      const stored = localStorage.getItem('reportx_session');
-      if (!stored) return null;
-      try {
-        const session = JSON.parse(stored);
-        return session?.accessToken || null;
-      } catch {
-        return null;
-      }
-    })();
+    const accessToken = getAccessToken();
 
     if (!accessToken) {
       setStatusMessage('Unable to find authenticated session. Please log in.');
@@ -132,16 +237,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
   async function revokeShare() {
     if (!report) return;
 
-    const accessToken = (() => {
-      const stored = localStorage.getItem('reportx_session');
-      if (!stored) return null;
-      try {
-        const session = JSON.parse(stored);
-        return session?.accessToken || null;
-      } catch {
-        return null;
-      }
-    })();
+    const accessToken = getAccessToken();
 
     if (!accessToken) {
       setStatusMessage('Unable to find authenticated session. Please log in.');
@@ -175,7 +271,50 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
     }
   }
 
-  const interpretation = report.interpretation;
+  const interpretation = report?.interpretation;
+  const trendItems = trends.filter((item) => item.sparkline.length > 1);
+  const normalizedFilter = biomarkerFilterText.trim().toLowerCase();
+  const filteredTrendItems = trendItems.filter((item) => {
+    if (!normalizedFilter) return true;
+    const label = `${item.display_name} ${item.biomarker_key}`.toLowerCase();
+    return label.includes(normalizedFilter);
+  });
+
+  useEffect(() => {
+    if (filteredTrendItems.length === 0) {
+      setSelectedBiomarkerKey('');
+      return;
+    }
+
+    const stillExists = filteredTrendItems.some((item) => item.biomarker_key === selectedBiomarkerKey);
+    if (!stillExists) {
+      setSelectedBiomarkerKey(filteredTrendItems[0].biomarker_key);
+    }
+  }, [filteredTrendItems, selectedBiomarkerKey]);
+
+  const selectedTrend = filteredTrendItems.find((item) => item.biomarker_key === selectedBiomarkerKey)
+    || filteredTrendItems[0]
+    || null;
+
+  if (!user) {
+    return (
+      <ProtectedView>
+        <div>Loading...</div>
+      </ProtectedView>
+    );
+  }
+
+  if (!report) {
+    return (
+      <ProtectedView>
+        <section className="stack">
+          <h1>Report Not Found</h1>
+          <p>This report does not exist or you do not have permission to view it.</p>
+          {statusMessage && <div className="alert alert-error" style={{ marginTop: '1rem' }}>{statusMessage}</div>}
+        </section>
+      </ProtectedView>
+    );
+  }
 
   return (
     <ProtectedView>
@@ -202,6 +341,70 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
             <p>{interpretation.summary}</p>
           </div>
         )}
+
+        <div className="card">
+          <h2>Biomarker Trends</h2>
+          {trendsLoading ? <p>Loading trends…</p> : null}
+          {!trendsLoading && trendsError ? <p>{trendsError}</p> : null}
+          {!trendsLoading && !trendsError && trendItems.length === 0 ? (
+            <p>Not enough prior report data to calculate trends yet.</p>
+          ) : null}
+          {!trendsLoading && !trendsError && trendItems.length > 0 ? (
+            <>
+              <div className="field" style={{ maxWidth: '420px' }}>
+                <label htmlFor="biomarker-filter">Filter biomarkers</label>
+                <input
+                  id="biomarker-filter"
+                  placeholder="Type biomarker name"
+                  value={biomarkerFilterText}
+                  onChange={(e) => setBiomarkerFilterText(e.target.value)}
+                />
+              </div>
+              <div className="field" style={{ maxWidth: '420px' }}>
+                <label htmlFor="biomarker-select">Biomarker</label>
+                <select
+                  id="biomarker-select"
+                  value={selectedTrend?.biomarker_key || ''}
+                  onChange={(e) => setSelectedBiomarkerKey(e.target.value)}
+                >
+                  {filteredTrendItems.map((item) => (
+                    <option key={item.biomarker_key} value={item.biomarker_key}>
+                      {item.display_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="field" style={{ maxWidth: '320px' }}>
+                <label htmlFor="trend-language">Trend note language</label>
+                <select
+                  id="trend-language"
+                  value={trendLanguage}
+                  onChange={(e) => setTrendLanguage(e.target.value)}
+                >
+                  {LANGUAGE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </div>
+              {loadingTrendTranslations ? <p>Loading translation…</p> : null}
+              {trendTranslationError ? <p>{trendTranslationError}</p> : null}
+              {!selectedTrend ? <p>No biomarkers match your filter.</p> : null}
+              {selectedTrend ? (
+                <>
+                  <p>{trendNoteTranslations[selectedTrend.biomarker_key]?.[trendLanguage] || selectedTrend.trend_note}</p>
+                  <BiomarkerTrendChart
+                    title={selectedTrend.display_name}
+                    unit={selectedTrend.unit}
+                    points={selectedTrend.sparkline.map((point) => ({
+                      observed_at: point.observed_at,
+                      value: point.value,
+                    }))}
+                  />
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </div>
 
         <div className="card">
           <h2>Sharing Preferences</h2>
@@ -237,6 +440,8 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
           {sharingPreferences.active && <button className="nav-btn nav-btn-danger" onClick={revokeShare} style={{ marginLeft: '0.5rem' }}>Revoke</button>}
           {statusMessage && <p>{statusMessage}</p>}
         </div>
+
+        <Disclaimer />
 
       </section>
     </ProtectedView>

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -41,7 +41,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
   const [loadingTrendTranslations, setLoadingTrendTranslations] = useState(false);
   const [trendTranslationError, setTrendTranslationError] = useState<string | null>(null);
   const [trendNoteTranslations, setTrendNoteTranslations] = useState<Record<string, Record<string, string>>>({});
-  const [prefetchedTrendLanguages, setPrefetchedTrendLanguages] = useState<Record<string, boolean>>({});
+  const [prefetchedTrendLanguages, setPrefetchedTrendLanguages] = useState<Record<string, Record<string, boolean>>>({});
   const [biomarkerFilterText, setBiomarkerFilterText] = useState('');
   const [selectedBiomarkerKey, setSelectedBiomarkerKey] = useState('');
 
@@ -127,7 +127,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
 
     const withEnoughPoints = trends.filter((item) => item.sparkline.length > 1);
     const toTranslate = withEnoughPoints.filter(
-      (item) => !trendNoteTranslations[item.biomarker_key]?.[languageCode] && !prefetchedTrendLanguages[item.biomarker_key],
+      (item) => !trendNoteTranslations[item.biomarker_key]?.[languageCode] && !prefetchedTrendLanguages[item.biomarker_key]?.[languageCode],
     );
 
     if (toTranslate.length === 0) return;
@@ -172,7 +172,11 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
       setPrefetchedTrendLanguages((prev) => {
         const next = { ...prev };
         for (const item of translated) {
-          next[item.biomarkerKey] = true;
+          const langMap = { ...(next[item.biomarkerKey] || {}) };
+          for (const lang of Object.keys(item.translations)) {
+            langMap[lang] = true;
+          }
+          next[item.biomarkerKey] = langMap;
         }
         return next;
       });
@@ -211,7 +215,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
         },
         body: JSON.stringify({
           clinician_email: sharingPreferences.clinicianEmail,
-          scope: 'report',
+          scope: sharingPreferences.scope === 'full' ? 'patient' : 'report',
           access_level: sharingPreferences.scope === 'full' ? 'comment' : 'read',
           expires_at: new Date(sharingPreferences.expiresAt).toISOString(),
         }),

--- a/frontend/src/app/reports/__tests__/ReportsFlow.test.tsx
+++ b/frontend/src/app/reports/__tests__/ReportsFlow.test.tsx
@@ -138,12 +138,12 @@ describe('Report history and sharing preference flow', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /report a/i })).toBeInTheDocument();
+      expect(screen.getAllByText('Report A').length).toBeGreaterThan(0);
     });
 
     expect(screen.queryByText('Report B')).toBeNull();
-    expect(screen.getByRole('button', { name: /open report/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /manage sharing preferences/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /^open$/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /^sharing$/i }).length).toBeGreaterThan(0);
   });
 
   it('shows one timeline trend graph on history page with all uploaded report dates on x-axis', async () => {

--- a/frontend/src/app/reports/__tests__/ReportsFlow.test.tsx
+++ b/frontend/src/app/reports/__tests__/ReportsFlow.test.tsx
@@ -46,6 +46,40 @@ describe('Report history and sharing preference flow', () => {
           headers: { 'Content-Type': 'application/json' },
         });
       }
+      if (url.includes('/api/v1/reports/') && url.endsWith('/trends')) {
+        return new Response(JSON.stringify({
+          report_id: 'report-1',
+          subject_user_id: 'patient-id',
+          trends: [
+            {
+              biomarker_key: 'hgb',
+              display_name: 'Hgb',
+              unit: 'g/dL',
+              direction: 'improving',
+              trend_note: 'Hemoglobin trend appears to be improving compared with prior reports.',
+              sparkline: [
+                {
+                  report_id: 'older-report',
+                  observed_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+                  value: 12.7,
+                  unit: 'g/dL',
+                  flag: 'normal',
+                },
+                {
+                  report_id: 'report-1',
+                  observed_at: new Date().toISOString(),
+                  value: 13.5,
+                  unit: 'g/dL',
+                  flag: 'normal',
+                },
+              ],
+            },
+          ],
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/v1/reports/') && !url.includes('/share')) {
         // report detail endpoint
         const reportId = url.split('/').pop();
@@ -104,12 +138,100 @@ describe('Report history and sharing preference flow', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Report A')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /report a/i })).toBeInTheDocument();
     });
 
     expect(screen.queryByText('Report B')).toBeNull();
     expect(screen.getByRole('button', { name: /open report/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /manage sharing preferences/i })).toBeInTheDocument();
+  });
+
+  it('shows one timeline trend graph on history page with all uploaded report dates on x-axis', async () => {
+    const d1 = '2026-01-05T00:00:00Z';
+    const d2 = '2026-02-05T00:00:00Z';
+    const d3 = '2026-03-05T00:00:00Z';
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/v1/reports')) {
+        return new Response(JSON.stringify([
+          {
+            id: 'report-3',
+            title: 'Report 3',
+            source_kind: 'text',
+            sharing_mode: 'private',
+            observed_at: d3,
+            findings: [
+              { id: 'r3a', biomarker_key: 'ALT', display_name: 'Alanine Aminotransferase (ALT)', value_numeric: 58, value_text: null, unit: 'U/L', flag: 'high', reference_range_text: '11-15' },
+              { id: 'r3b', biomarker_key: 'AST', display_name: 'Aspartate Aminotransferase (AST)', value_numeric: 45, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '10-40' },
+            ],
+          },
+          {
+            id: 'report-2',
+            title: 'Report 2',
+            source_kind: 'text',
+            sharing_mode: 'private',
+            observed_at: d2,
+            findings: [
+              { id: 'r2a', biomarker_key: 'ALT', display_name: 'Alanine Aminotransferase (ALT)', value_numeric: 34, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '11-15' },
+              { id: 'r2b', biomarker_key: 'AST', display_name: 'Aspartate Aminotransferase (AST)', value_numeric: 31, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '10-40' },
+              { id: 'r2c', biomarker_key: 'ALP', display_name: 'Alkaline Phosphatase (ALP)', value_numeric: 74, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '45-120' },
+            ],
+          },
+          {
+            id: 'report-1',
+            title: 'Report 1',
+            source_kind: 'text',
+            sharing_mode: 'private',
+            observed_at: d1,
+            findings: [
+              { id: 'r1a', biomarker_key: 'ALT', display_name: 'Alanine Aminotransferase (ALT)', value_numeric: 29, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '11-15' },
+              { id: 'r1b', biomarker_key: 'AST', display_name: 'Aspartate Aminotransferase (AST)', value_numeric: 28, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '10-40' },
+              { id: 'r1c', biomarker_key: 'ALP', display_name: 'Alkaline Phosphatase (ALP)', value_numeric: 52, value_text: null, unit: 'U/L', flag: 'normal', reference_range_text: '45-120' },
+            ],
+          },
+        ]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/v1/reports/') && url.endsWith('/trends')) {
+        return new Response(JSON.stringify({
+          report_id: 'report-3',
+          subject_user_id: 'patient-id',
+          trends: [
+            {
+              biomarker_key: 'alt',
+              display_name: 'Alanine Aminotransferase (ALT)',
+              unit: 'U/L',
+              direction: 'worsening',
+              trend_note: 'Alanine Aminotransferase trend appears to be worsening compared with prior reports.',
+              sparkline: [
+                { report_id: 'report-1', observed_at: d1, value: 29, unit: 'U/L', flag: 'normal' },
+                { report_id: 'report-2', observed_at: d2, value: 34, unit: 'U/L', flag: 'normal' },
+                { report_id: 'report-3', observed_at: d3, value: 58, unit: 'U/L', flag: 'high' },
+              ],
+            },
+          ],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    render(
+      <AuthProvider>
+        <ReportsPage />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: /biomarker timeline chart/i })).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/select biomarker/i)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /alanine aminotransferase/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /aspartate aminotransferase/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /alkaline phosphatase/i })).toBeInTheDocument();
   });
 
   it('navigates into report detail and allows sharing preference update', async () => {
@@ -228,6 +350,85 @@ describe('Report history and sharing preference flow', () => {
         expect.stringContaining('/api/v1/reports/'),
         expect.objectContaining({ method: 'POST' }),
       );
+    });
+  });
+
+  it('renders biomarker trend chart with filter controls on report detail', async () => {
+    const report = addReportToHistory({
+      patientEmail: 'patient@example.com',
+      title: 'Report D',
+      rows: [],
+      unparsed: [],
+    });
+
+    render(
+      <AuthProvider>
+        <ReportDetailPage params={{ reportId: report.id }} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /biomarker trends/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/filter biomarkers/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^biomarker$/i)).toBeInTheDocument();
+    expect(screen.getByText(/hemoglobin trend appears to be improving/i)).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /biomarker trend chart/i })).toBeInTheDocument();
+    expect(screen.getByText(/x-axis: observation date/i)).toBeInTheDocument();
+    expect(screen.getByText(/y-axis: value/i)).toBeInTheDocument();
+  });
+
+  it('shows access-aware trend message when trends endpoint is forbidden', async () => {
+    const report = addReportToHistory({
+      patientEmail: 'patient@example.com',
+      title: 'Report E',
+      rows: [],
+      unparsed: [],
+    });
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes('/api/v1/reports/') && url.endsWith('/trends')) {
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      if (url.includes('/api/v1/reports/') && !url.includes('/share')) {
+        const reportId = url.split('/').pop();
+        return new Response(JSON.stringify({
+          report: {
+            id: reportId,
+            subject_user_id: 'patient-id',
+            created_by_user_id: 'patient-id',
+            title: 'Report E',
+            source_kind: 'text',
+            sharing_mode: 'private',
+            observed_at: new Date().toISOString(),
+            findings: [],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      if (url.includes('/api/v1/reports/') && url.endsWith('/share')) {
+        return new Response(JSON.stringify({ id: 'share-1' }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      if (url.includes('/api/v1/reports/') && url.endsWith('/share/revoke')) {
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    render(
+      <AuthProvider>
+        <ReportDetailPage params={{ reportId: report.id }} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/trend details require full-report sharing access for clinician views/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ProtectedView } from '@/components/ProtectedView';
 import { useAuth } from '@/store/authStore';
 import { fetchReportHistory } from '@/lib/reportHistory';
@@ -19,7 +19,7 @@ export default function ReportsPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
 
-  async function fetchReports() {
+  const fetchReports = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -33,15 +33,11 @@ export default function ReportsPage() {
       setLoadError(err?.message || 'Failed to load report history.');
       setStatusMessage('');
     }
-  }
+  }, [user]);
 
   useEffect(() => {
     void fetchReports();
-  }, [user]);
-
-  function refresh() {
-    void fetchReports();
-  }
+  }, [fetchReports]);
 
   function beginSharing(entry: ReportHistoryEntry) {
     setEditingSharingId(entry.id);

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -9,6 +9,35 @@ import { BiomarkerTimelineChart } from '@/components/BiomarkerTimelineChart';
 import { buildBiomarkerTimeline } from '@/lib/reportTimeline';
 import { resolveReportDate } from '@/lib/reportHistory';
 
+type SortDirection = 'desc' | 'asc';
+
+function formatReportDate(ts: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(ts));
+}
+
+function resolvePanelShortName(entry: ReportHistoryEntry): string | null {
+  const explicit = entry.panelName?.trim();
+  if (explicit) return explicit;
+
+  const fromTitle = entry.title?.match(/\b(LFT|KFT|FBC|CBC|BMP|CMP|LIPID|TFT)\b/i)?.[1];
+  if (fromTitle) return fromTitle.toUpperCase();
+
+  return null;
+}
+
+function hasActualReportDate(entry: ReportHistoryEntry): boolean {
+  return typeof entry.reportDate === 'number' && Number.isFinite(entry.reportDate);
+}
+
+function uploadDate(entry: ReportHistoryEntry): number {
+  if (typeof entry.savedAt === 'number' && Number.isFinite(entry.savedAt)) return entry.savedAt;
+  return entry.createdAt;
+}
+
 export default function ReportsPage() {
   const { user } = useAuth();
   const [reportHistory, setReportHistory] = useState<ReportHistoryEntry[]>([]);
@@ -16,6 +45,7 @@ export default function ReportsPage() {
   const [sheet, setSheet] = useState<SharingPreferences>({ clinicianEmail: '', scope: 'summary', expiresAt: Date.now() + 86400000, active: false });
   const [statusMessage, setStatusMessage] = useState('');
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
 
   const fetchReports = useCallback(async () => {
@@ -38,6 +68,39 @@ export default function ReportsPage() {
   const timeline = useMemo(() => buildBiomarkerTimeline(reportHistory), [reportHistory]);
   const reportCards = useMemo(() => [...timeline.reports].sort((a, b) => b.reportDate - a.reportDate), [timeline.reports]);
   const reportCardById = useMemo(() => new Map(reportCards.map((item) => [item.id, item])), [reportCards]);
+  const reportById = useMemo(() => new Map(reportHistory.map((entry) => [entry.id, entry])), [reportHistory]);
+
+  const rows = useMemo(() => {
+    const items = reportHistory
+      .map((entry) => {
+        const card = reportCardById.get(entry.id);
+        if (!card) return null;
+
+        const actualDateAvailable = hasActualReportDate(entry);
+        const dateValue = actualDateAvailable ? (entry.reportDate as number) : uploadDate(entry);
+        return {
+          entry,
+          card,
+          panelName: resolvePanelShortName(entry),
+          actualDateAvailable,
+          displayDate: formatReportDate(dateValue),
+          sortDate: dateValue,
+        };
+      })
+      .filter(Boolean) as Array<{
+      entry: ReportHistoryEntry;
+      card: (typeof reportCards)[number];
+      panelName: string | null;
+      actualDateAvailable: boolean;
+      displayDate: string;
+      sortDate: number;
+    }>;
+
+    items.sort((a, b) => (sortDirection === 'desc' ? b.sortDate - a.sortDate : a.sortDate - b.sortDate));
+    return items;
+  }, [reportHistory, reportCardById, sortDirection]);
+
+  const reportCountLabel = `${rows.length} report${rows.length === 1 ? '' : 's'} on file`;
 
   useEffect(() => {
     void fetchReports();
@@ -141,7 +204,7 @@ export default function ReportsPage() {
     <ProtectedView>
       <section className="stack">
         <h1>My Report History</h1>
-        <p>These are your own reports, saved locally in your browser session.</p>
+        <p className="history-summary">{reportCountLabel}</p>
         {loadError && (
           <div className="alert alert-error" style={{ marginBottom: '1rem' }}>
             {loadError}
@@ -150,55 +213,98 @@ export default function ReportsPage() {
 
         <BiomarkerTimelineChart reports={reportHistory} />
 
-        {reportHistory.length === 0 ? (
-          <div className="card">
-            <p>You don&apos;t have any reports yet. Please <a href="/parse">review a report</a> first.</p>
-          </div>
-        ) : (
-          <div className="card">
-            {reportHistory.map((entry) => {
-              const card = reportCardById.get(entry.id);
-              if (!card) return null;
-              return (
-              <article
-                key={entry.id}
-                className="card"
-                style={{
-                  marginBottom: '0.75rem',
-                  borderLeft: `4px solid ${card.accentColor}`,
-                }}
-              >
-                <h3>{card.displayTitle}</h3>
-                <p><small>Report date: {card.reportDateLabel}</small></p>
-                <p>{card.testCount} test results</p>
-                <p>
-                  <span
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      padding: '0.35rem 0.75rem',
-                      borderRadius: '999px',
-                      background: card.hasInterpretation ? '#E6F6F7' : '#E5E7EB',
-                      color: card.hasInterpretation ? '#077B82' : '#6B7280',
-                      fontSize: '0.875rem',
-                      fontWeight: 600,
-                    }}
+        <div className="report-history-table-card" role="region" aria-label="Report history table">
+          <table className="report-history-table">
+            <thead>
+              <tr>
+                <th>
+                  <button
+                    type="button"
+                    className="report-history-sort"
+                    onClick={() => setSortDirection((prev) => (prev === 'desc' ? 'asc' : 'desc'))}
+                    aria-label={`Sort by report date ${sortDirection === 'desc' ? 'oldest first' : 'newest first'}`}
                   >
-                    {card.hasInterpretation ? 'Interpreted' : 'No interpretation yet'}
-                  </span>
-                </p>
-                <div style={{ display: 'flex', gap: '0.75rem' }}>
-                  <button className="nav-btn nav-btn-primary" onClick={() => (window.location.href = `/reports/${entry.id}`)}>Open Report</button>
-                  <button className="nav-btn nav-btn-outline" onClick={() => beginSharing(entry)}>Manage Sharing Preferences</button>
-                  {entry.sharingPreferences?.active && (
-                    <button className="nav-btn nav-btn-danger" onClick={() => revokeSharing(entry.id)}>Revoke Share</button>
-                  )}
-                </div>
-              </article>
-              );
-            })}
+                    <span>Report date</span>
+                    <span aria-hidden="true">{sortDirection === 'desc' ? '▾' : '▴'}</span>
+                  </button>
+                </th>
+                <th>Panel / type</th>
+                <th>Test results</th>
+                <th>Interpretation</th>
+                <th className="actions-col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr className="empty-row">
+                  <td colSpan={5}>No reports uploaded yet.</td>
+                </tr>
+              ) : (
+                rows.map(({ entry, card, panelName, actualDateAvailable, displayDate }) => (
+                  <tr key={entry.id}>
+                    <td className="date-col" style={{ boxShadow: `inset 4px 0 0 ${card.accentColor}` }}>
+                      {actualDateAvailable ? (
+                        <span className="report-date-text">{displayDate}</span>
+                      ) : (
+                        <span className="report-date-fallback" title="Actual report date unavailable">
+                          {displayDate} <span className="help-icon" aria-hidden="true">?</span>
+                        </span>
+                      )}
+                    </td>
+                    <td>
+                      {panelName ? <span>{panelName}</span> : <span className="muted-cell">Unknown panel</span>}
+                    </td>
+                    <td className="results-col">{card.testCount} results</td>
+                    <td>
+                      <span className={`interp-pill ${card.hasInterpretation ? 'yes' : 'no'}`}>
+                        {card.hasInterpretation ? 'Interpreted' : 'Not interpreted'}
+                      </span>
+                    </td>
+                    <td className="actions-col">
+                      <div className="table-actions">
+                        <button className="table-btn table-btn-primary" onClick={() => (window.location.href = `/reports/${entry.id}`)}>Open</button>
+                        <button className="table-btn table-btn-ghost" onClick={() => beginSharing(entry)}>Sharing</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+
+          <div className="report-history-mobile-list" aria-label="Report history mobile list">
+            {rows.length === 0 ? (
+              <div className="mobile-empty">No reports uploaded yet.</div>
+            ) : (
+              rows.map(({ entry, card, panelName, actualDateAvailable, displayDate }) => (
+                <article key={entry.id} className="mobile-report-row" style={{ boxShadow: `inset 0 4px 0 ${card.accentColor}` }}>
+                  <div className="mobile-line-1">
+                    <div className="mobile-date-panel">
+                      {actualDateAvailable ? (
+                        <span className="mobile-date">{displayDate}</span>
+                      ) : (
+                        <span className="mobile-date muted" title="Actual report date unavailable">
+                          {displayDate} <span className="help-icon" aria-hidden="true">?</span>
+                        </span>
+                      )}
+                      <span className={`mobile-panel ${panelName ? '' : 'muted-cell'}`}>{panelName || 'Unknown panel'}</span>
+                    </div>
+                    <span className={`interp-pill ${card.hasInterpretation ? 'yes' : 'no'}`}>
+                      {card.hasInterpretation ? 'Interpreted' : 'Not interpreted'}
+                    </span>
+                  </div>
+                  <div className="mobile-line-2">
+                    <span className="results-col">{card.testCount} results</span>
+                    <div className="table-actions">
+                      <button className="table-btn table-btn-primary" onClick={() => (window.location.href = `/reports/${entry.id}`)}>Open</button>
+                      <button className="table-btn table-btn-ghost" onClick={() => beginSharing(entry)}>Sharing</button>
+                    </div>
+                  </div>
+                </article>
+              ))
+            )}
           </div>
-        )}
+        </div>
 
         {editingSharingId && (
           <div className="card" style={{ marginTop: '1.25rem' }}>

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -68,7 +68,6 @@ export default function ReportsPage() {
   const timeline = useMemo(() => buildBiomarkerTimeline(reportHistory), [reportHistory]);
   const reportCards = useMemo(() => [...timeline.reports].sort((a, b) => b.reportDate - a.reportDate), [timeline.reports]);
   const reportCardById = useMemo(() => new Map(reportCards.map((item) => [item.id, item])), [reportCards]);
-  const reportById = useMemo(() => new Map(reportHistory.map((entry) => [entry.id, entry])), [reportHistory]);
 
   const rows = useMemo(() => {
     const items = reportHistory
@@ -136,7 +135,7 @@ export default function ReportsPage() {
         },
         body: JSON.stringify({
           clinician_email: sheet.clinicianEmail,
-          scope: sheet.scope === 'full' ? 'report' : 'patient',
+          scope: sheet.scope === 'full' ? 'patient' : 'report',
           access_level: sheet.scope === 'full' ? 'comment' : 'read',
           expires_at: new Date(sheet.expiresAt).toISOString(),
         }),

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ProtectedView } from '@/components/ProtectedView';
 import { useAuth } from '@/store/authStore';
 import { fetchReportHistory } from '@/lib/reportHistory';
 import type { ReportHistoryEntry, SharingPreferences } from '@/lib/reportHistory';
-
-function formatDate(ts: number) {
-  return new Date(ts).toLocaleString();
-}
+import { BiomarkerTimelineChart } from '@/components/BiomarkerTimelineChart';
+import { buildBiomarkerTimeline } from '@/lib/reportTimeline';
+import { resolveReportDate } from '@/lib/reportHistory';
 
 export default function ReportsPage() {
   const { user } = useAuth();
@@ -24,7 +23,8 @@ export default function ReportsPage() {
 
     try {
       const data = await fetchReportHistory();
-      setReportHistory(data);
+      setReportHistory([...data].sort((a, b) => resolveReportDate(b) - resolveReportDate(a)));
+
       setLoadError(null);
       setStatusMessage('');
     } catch (err: any) {
@@ -34,6 +34,10 @@ export default function ReportsPage() {
       setStatusMessage('');
     }
   }, [user]);
+
+  const timeline = useMemo(() => buildBiomarkerTimeline(reportHistory), [reportHistory]);
+  const reportCards = useMemo(() => [...timeline.reports].sort((a, b) => b.reportDate - a.reportDate), [timeline.reports]);
+  const reportCardById = useMemo(() => new Map(reportCards.map((item) => [item.id, item])), [reportCards]);
 
   useEffect(() => {
     void fetchReports();
@@ -144,18 +148,45 @@ export default function ReportsPage() {
           </div>
         )}
 
+        <BiomarkerTimelineChart reports={reportHistory} />
+
         {reportHistory.length === 0 ? (
           <div className="card">
             <p>You don&apos;t have any reports yet. Please <a href="/parse">review a report</a> first.</p>
           </div>
         ) : (
           <div className="card">
-            {reportHistory.map((entry) => (
-              <article key={entry.id} className="card" style={{ marginBottom: '0.75rem' }}>
-                <h3>{entry.title || 'Untitled Report'}</h3>
-                <p><small>Saved: {formatDate(entry.createdAt)}</small></p>
-                <p>Rows: {entry.rows?.length ?? 0}</p>
-                <p>Interpretation: {entry.interpretation ? 'Yes' : 'No'}</p>
+            {reportHistory.map((entry) => {
+              const card = reportCardById.get(entry.id);
+              if (!card) return null;
+              return (
+              <article
+                key={entry.id}
+                className="card"
+                style={{
+                  marginBottom: '0.75rem',
+                  borderLeft: `4px solid ${card.accentColor}`,
+                }}
+              >
+                <h3>{card.displayTitle}</h3>
+                <p><small>Report date: {card.reportDateLabel}</small></p>
+                <p>{card.testCount} test results</p>
+                <p>
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      padding: '0.35rem 0.75rem',
+                      borderRadius: '999px',
+                      background: card.hasInterpretation ? '#E6F6F7' : '#E5E7EB',
+                      color: card.hasInterpretation ? '#077B82' : '#6B7280',
+                      fontSize: '0.875rem',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {card.hasInterpretation ? 'Interpreted' : 'No interpretation yet'}
+                  </span>
+                </p>
                 <div style={{ display: 'flex', gap: '0.75rem' }}>
                   <button className="nav-btn nav-btn-primary" onClick={() => (window.location.href = `/reports/${entry.id}`)}>Open Report</button>
                   <button className="nav-btn nav-btn-outline" onClick={() => beginSharing(entry)}>Manage Sharing Preferences</button>
@@ -164,7 +195,8 @@ export default function ReportsPage() {
                   )}
                 </div>
               </article>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/frontend/src/components/BiomarkerTimelineChart.tsx
+++ b/frontend/src/components/BiomarkerTimelineChart.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  Filler,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  TimeScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import { Line } from 'react-chartjs-2';
+import 'chartjs-adapter-date-fns';
+
+import type { ReportHistoryEntry } from '@/lib/reportHistory';
+import { buildBiomarkerTimeline } from '@/lib/reportTimeline';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, TimeScale, Filler, Tooltip, Legend, annotationPlugin);
+
+export function BiomarkerTimelineChart({ reports }: { reports: ReportHistoryEntry[] }) {
+  const [selectedBiomarkerKey, setSelectedBiomarkerKey] = useState('');
+
+  const timeline = useMemo(() => buildBiomarkerTimeline(reports), [reports]);
+
+  const chartSpanYears = useMemo(() => {
+    if (timeline.reportDates.length < 2) return 0;
+    const min = Math.min(...timeline.reportDates);
+    const max = Math.max(...timeline.reportDates);
+    return (max - min) / (365.25 * 24 * 60 * 60 * 1000);
+  }, [timeline.reportDates]);
+
+  const timeUnit = chartSpanYears > 2 ? 'year' : 'month';
+
+  const activeSeries = useMemo(() => {
+    if (timeline.series.length === 0) return [];
+    const chosen = timeline.series.find((item) => item.biomarkerKey === selectedBiomarkerKey);
+    return [chosen ?? timeline.series[0]];
+  }, [selectedBiomarkerKey, timeline.series]);
+
+  const selectedSeries = activeSeries[0] ?? null;
+  const visibleCount = activeSeries.length;
+
+  const activeReportDates = timeline.reportDates;
+
+  const chartData: ChartData<'line'> = {
+    datasets: activeSeries.map((series) => ({
+      label: series.displayName,
+      data: series.points,
+      borderColor: series.color,
+      backgroundColor: series.color,
+      pointBackgroundColor: (ctx) => {
+        const raw = ctx.raw as any;
+        if (!raw || raw.y === null || raw.y === undefined) return 'transparent';
+        const low = series.referenceRangeLow;
+        const high = series.referenceRangeHigh;
+        const isOutOfRange = typeof raw.y === 'number' && ((typeof low === 'number' && raw.y < low) || (typeof high === 'number' && raw.y > high) || raw.flag === 'low' || raw.flag === 'high' || raw.flag === 'abnormal');
+        return isOutOfRange ? '#ef4444' : series.color;
+      },
+      pointBorderColor: (ctx) => {
+        const raw = ctx.raw as any;
+        if (!raw || raw.y === null || raw.y === undefined) return 'transparent';
+        return '#ffffff';
+      },
+      pointRadius: 4,
+      pointHoverRadius: 6,
+      pointBorderWidth: 2,
+      tension: 0.35,
+      fill: false,
+      spanGaps: false,
+      borderWidth: 2,
+      parsing: false,
+    })),
+  };
+
+  const annotations: any = {};
+  if (visibleCount === 1) {
+    const series = activeSeries[0];
+    if (typeof series.referenceRangeLow === 'number' && typeof series.referenceRangeHigh === 'number') {
+      annotations.referenceBand = {
+        type: 'box',
+        xMin: activeReportDates[0],
+        xMax: activeReportDates[activeReportDates.length - 1],
+        yMin: series.referenceRangeLow,
+        yMax: series.referenceRangeHigh,
+        backgroundColor: 'rgba(40, 167, 69, 0.10)',
+        borderWidth: 0,
+      };
+    }
+  }
+
+  const options: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'x',
+      intersect: false,
+    },
+    plugins: {
+      legend: { display: false },
+      annotation: { annotations: annotations as any },
+      tooltip: {
+        backgroundColor: '#ffffff',
+        borderColor: '#e5e7eb',
+        borderWidth: 1,
+        cornerRadius: 8,
+        padding: 10,
+        titleColor: '#111827',
+        bodyColor: '#111827',
+        titleFont: { size: 13, weight: 600 },
+        bodyFont: { size: 13 },
+        boxPadding: 4,
+        usePointStyle: true,
+        callbacks: {
+          title(items) {
+            const raw = items[0]?.raw as any;
+            const value = raw?.x ?? raw?.reportDate ?? null;
+            if (!value) return '';
+            return new Intl.DateTimeFormat(undefined, {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+            }).format(new Date(value));
+          },
+          label(context) {
+            const raw = context.raw as any;
+            if (!raw || raw.y === null || raw.y === undefined) return '';
+            const point = raw;
+            const unit = point.unit ? ` ${point.unit}` : '';
+            const ref = point.referenceRangeText ? ` • Ref ${point.referenceRangeText}` : '';
+            const matchingSeries = activeSeries.find((item) => item.displayName === context.dataset.label);
+            const outOfRangeHigh = matchingSeries && typeof matchingSeries.referenceRangeHigh === 'number' && typeof point.y === 'number' && point.y > matchingSeries.referenceRangeHigh;
+            const outOfRangeLow = matchingSeries && typeof matchingSeries.referenceRangeLow === 'number' && typeof point.y === 'number' && point.y < matchingSeries.referenceRangeLow;
+            let flag = '';
+            if (point.flag === 'high' || point.flag === 'abnormal' || outOfRangeHigh) {
+              flag = ' • ↑ High';
+            } else if (point.flag === 'low' || outOfRangeLow) {
+              flag = ' • ↓ Low';
+            }
+            return `${context.dataset.label}: ${point.y}${unit}${flag}${ref}`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        type: 'time',
+        time: {
+          unit: timeUnit,
+          tooltipFormat: 'dd MMM yyyy',
+          displayFormats: {
+            month: 'dd MMM yyyy',
+            year: 'yyyy',
+          },
+        },
+        ticks: {
+          source: 'data',
+          autoSkip: false,
+          color: '#6b7280',
+          font: { size: 12 },
+          maxRotation: 35,
+          minRotation: 35,
+        },
+        title: {
+          display: true,
+          text: 'Report date (lab test date)',
+          color: '#6b7280',
+          font: { size: 12 },
+        },
+        grid: {
+          display: false,
+        },
+        border: {
+          display: false,
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: 'Value',
+          color: '#6b7280',
+          font: { size: 12 },
+        },
+        ticks: {
+          color: '#6b7280',
+          font: { size: 12 },
+        },
+        grid: {
+          color: '#f0f0f0',
+          lineWidth: 0.5,
+        },
+        border: {
+          display: false,
+        },
+      },
+    },
+  };
+
+  if (reports.length < 2) {
+    return (
+      <div className="biomarker-timeline-empty">
+        Upload at least 2 reports to see biomarker trends over time.
+      </div>
+    );
+  }
+
+  return (
+    <div className="biomarker-timeline-card">
+      <div className="biomarker-timeline-toolbar">
+        <div className="field biomarker-timeline-filter">
+          <label htmlFor="biomarker-filter">Select biomarker</label>
+          <select
+            id="biomarker-filter"
+            value={selectedSeries?.biomarkerKey ?? selectedBiomarkerKey}
+            onChange={(e) => setSelectedBiomarkerKey(e.target.value)}
+          >
+            {timeline.series.map((series) => (
+              <option key={series.biomarkerKey} value={series.biomarkerKey}>
+                {series.displayName}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {timeline.series.length === 0 ? (
+        <div className="biomarker-timeline-empty">
+          No biomarkers available for trend visualization.
+        </div>
+      ) : (
+        <div className="biomarker-timeline-shell" role="img" aria-label="Biomarker timeline chart">
+          <Line data={chartData} options={options} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BiomarkerTrendChart.tsx
+++ b/frontend/src/components/BiomarkerTrendChart.tsx
@@ -1,0 +1,124 @@
+type ChartPoint = {
+  observed_at: string;
+  value: number;
+};
+
+function formatDateLabel(value: string) {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return value;
+  const dt = new Date(timestamp);
+  const date = new Intl.DateTimeFormat(undefined, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(dt);
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(dt);
+  return `${date}|${time}`;
+}
+
+export function BiomarkerTrendChart({
+  title,
+  points,
+  unit,
+  observationDates,
+  width = 760,
+  height = 300,
+}: {
+  title: string;
+  points: ChartPoint[];
+  unit: string | null;
+  observationDates?: string[];
+  width?: number;
+  height?: number;
+}) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return null;
+  }
+
+  const sorted = [...points].sort((a, b) => Date.parse(a.observed_at) - Date.parse(b.observed_at));
+  const values = sorted.map((point) => point.value);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const valueRange = maxValue - minValue;
+  const timestamps = sorted.map((point) => Date.parse(point.observed_at));
+  const minTimestamp = Math.min(...timestamps);
+  const maxTimestamp = Math.max(...timestamps);
+  const timestampRange = Math.max(1, maxTimestamp - minTimestamp);
+
+  const margin = { top: 20, right: 26, bottom: 106, left: 56 };
+  const chartWidth = width - margin.left - margin.right;
+  const chartHeight = height - margin.top - margin.bottom;
+
+  const xForTimestamp = (timestamp: number) => {
+    const normalized = (timestamp - minTimestamp) / timestampRange;
+    return margin.left + normalized * chartWidth;
+  };
+
+  const path = sorted
+    .map((point) => {
+      const x = xForTimestamp(Date.parse(point.observed_at));
+      const normalized = valueRange === 0 ? 0.5 : (point.value - minValue) / valueRange;
+      const y = margin.top + (1 - normalized) * chartHeight;
+      return `${point === sorted[0] ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  const xAxisDateValues = Array.from(new Set((observationDates?.length ? observationDates : sorted.map((p) => p.observed_at))
+    .filter(Boolean)
+    .sort((a, b) => Date.parse(a) - Date.parse(b))));
+
+  return (
+    <figure style={{ margin: '0.75rem 0 0' }}>
+      <figcaption style={{ marginBottom: '0.5rem', fontWeight: 600 }}>{title}</figcaption>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label="Biomarker trend chart"
+      >
+        <line x1={margin.left} y1={margin.top + chartHeight} x2={margin.left + chartWidth} y2={margin.top + chartHeight} stroke="currentColor" strokeWidth="1" />
+        <line x1={margin.left} y1={margin.top} x2={margin.left} y2={margin.top + chartHeight} stroke="currentColor" strokeWidth="1" />
+
+        <path d={path} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+
+        <text x={margin.left - 8} y={margin.top + 4} textAnchor="end" fontSize="12">
+          {maxValue.toFixed(2)}
+        </text>
+        <text x={margin.left - 8} y={margin.top + chartHeight + 4} textAnchor="end" fontSize="12">
+          {minValue.toFixed(2)}
+        </text>
+
+        {xAxisDateValues.map((value) => {
+          const tickX = xForTimestamp(Date.parse(value));
+          const [datePart, timePart] = formatDateLabel(value).split('|');
+          return (
+            <g key={value}>
+              <line
+                x1={tickX}
+                y1={margin.top + chartHeight}
+                x2={tickX}
+                y2={margin.top + chartHeight + 6}
+                stroke="currentColor"
+                strokeWidth="1"
+              />
+              <text x={tickX} y={margin.top + chartHeight + 20} textAnchor="middle" fontSize="10">
+                <tspan x={tickX} dy="0">{datePart}</tspan>
+                <tspan x={tickX} dy="12">{timePart || ''}</tspan>
+              </text>
+            </g>
+          );
+        })}
+
+        <text x={margin.left + chartWidth / 2} y={height - 6} textAnchor="middle" fontSize="12">
+          X-axis: Observation date
+        </text>
+        <text x={8} y={margin.top + chartHeight / 2} fontSize="12">
+          Y-axis: Value {unit ? `(${unit})` : ''}
+        </text>
+      </svg>
+    </figure>
+  );
+}

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,61 @@
+type SparklinePoint = {
+  observed_at: string;
+  value: number;
+};
+
+function toNumber(value: number, fallback: number) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export function Sparkline({
+  points,
+  width = 180,
+  height = 44,
+  strokeWidth = 2,
+}: {
+  points: SparklinePoint[];
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+}) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return null;
+  }
+
+  const sorted = [...points].sort((a, b) => Date.parse(a.observed_at) - Date.parse(b.observed_at));
+  const values = sorted.map((p) => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const pad = strokeWidth;
+  const innerWidth = width - pad * 2;
+  const innerHeight = height - pad * 2;
+  const valueRange = max - min;
+
+  const d = sorted
+    .map((point, idx) => {
+      const x = pad + (idx / (sorted.length - 1)) * innerWidth;
+      const normalized = valueRange === 0 ? 0.5 : (point.value - min) / valueRange;
+      const y = pad + (1 - normalized) * innerHeight;
+      return `${idx === 0 ? 'M' : 'L'} ${toNumber(x, 0).toFixed(2)} ${toNumber(y, 0).toFixed(2)}`;
+    })
+    .join(' ');
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Biomarker trend sparkline"
+    >
+      <path
+        d={d}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/__tests__/BiomarkerTrendChart.test.tsx
+++ b/frontend/src/components/__tests__/BiomarkerTrendChart.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BiomarkerTrendChart } from '../BiomarkerTrendChart';
+
+describe('BiomarkerTrendChart', () => {
+  it('renders chart with x and y axis annotations', () => {
+    render(
+      <BiomarkerTrendChart
+        title="ALT"
+        unit="U/L"
+        points={[
+          { observed_at: '2026-01-01T00:00:00Z', value: 21 },
+          { observed_at: '2026-02-01T00:00:00Z', value: 35 },
+          { observed_at: '2026-03-01T00:00:00Z', value: 29 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: /biomarker trend chart/i })).toBeInTheDocument();
+    expect(screen.getByText(/x-axis: observation date/i)).toBeInTheDocument();
+    expect(screen.getByText(/y-axis: value/i)).toBeInTheDocument();
+  });
+
+  it('returns null for single observation', () => {
+    const { container } = render(
+      <BiomarkerTrendChart
+        title="ALT"
+        unit="U/L"
+        points={[{ observed_at: '2026-01-01T00:00:00Z', value: 21 }]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/__tests__/Sparkline.test.tsx
+++ b/frontend/src/components/__tests__/Sparkline.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Sparkline } from '../Sparkline';
+
+describe('Sparkline', () => {
+  it('renders svg when there are at least two points', () => {
+    render(
+      <Sparkline
+        points={[
+          { observed_at: '2026-01-01T00:00:00Z', value: 12.1 },
+          { observed_at: '2026-02-01T00:00:00Z', value: 12.8 },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('img', { name: /biomarker trend sparkline/i })).toBeInTheDocument();
+  });
+
+  it('returns null for single-point data', () => {
+    const { container } = render(
+      <Sparkline points={[{ observed_at: '2026-01-01T00:00:00Z', value: 12.1 }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/lib/reportHistory.ts
+++ b/frontend/src/lib/reportHistory.ts
@@ -124,8 +124,8 @@ export async function fetchReportHistory(): Promise<ReportHistoryEntry[]> {
       id: report.id,
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
-      createdAt: new Date(report.observed_at).getTime(),
-      savedAt: new Date(report.observed_at).getTime(),
+      createdAt: new Date(report.created_at).getTime(),
+      savedAt: new Date(report.created_at).getTime(),
       reportDate: new Date(report.observed_at).getTime(),
       panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: report.findings.map((f: any) => ({
@@ -186,8 +186,8 @@ export async function createReportEntry(input: {
       id: report.id,
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
-      createdAt: new Date(report.observed_at).getTime(),
-      savedAt: new Date(report.observed_at).getTime(),
+      createdAt: new Date(report.created_at).getTime(),
+      savedAt: new Date(report.created_at).getTime(),
       reportDate: new Date(report.observed_at).getTime(),
       panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: input.findings.map((f) => ({
@@ -227,8 +227,8 @@ export async function fetchReportById(reportId: string): Promise<ReportHistoryEn
       id: report.id,
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
-      createdAt: new Date(report.observed_at).getTime(),
-      savedAt: new Date(report.observed_at).getTime(),
+      createdAt: new Date(report.created_at).getTime(),
+      savedAt: new Date(report.created_at).getTime(),
       reportDate: new Date(report.observed_at).getTime(),
       panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: report.findings.map((f: any) => ({

--- a/frontend/src/lib/reportHistory.ts
+++ b/frontend/src/lib/reportHistory.ts
@@ -20,6 +20,9 @@ export type ReportHistoryEntry = {
   id: string;
   patientEmail: string;
   createdAt: number;
+  savedAt?: number;
+  reportDate?: number;
+  panelName?: string;
   title: string;
   rows: ParsedRow[];
   unparsed: string[];
@@ -29,6 +32,7 @@ export type ReportHistoryEntry = {
 };
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+const warnedMissingReportDate = new Set<string>();
 
 const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
 
@@ -59,6 +63,48 @@ function getSessionUserEmail(): string {
   return getStoredSession()?.user?.email || '';
 }
 
+function toTimestamp(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function isGenericReportTitle(title: string | null | undefined): boolean {
+  if (!title) return true;
+  const normalized = title.trim();
+  if (!normalized) return true;
+  return /^report\s+\d/i.test(normalized) || /\d{1,2}[\/.-]\d{1,2}[\/.-]\d{2,4}/.test(normalized);
+}
+
+function resolvePanelName(title: string | null | undefined, panelName?: string | null): string | null {
+  const explicit = panelName?.trim();
+  if (explicit) return explicit;
+  const candidate = title?.trim();
+  if (candidate && !isGenericReportTitle(candidate)) return candidate;
+  return null;
+}
+
+export function resolveReportDate(entry: Pick<ReportHistoryEntry, 'id' | 'createdAt'> & Partial<Pick<ReportHistoryEntry, 'savedAt' | 'reportDate'>>): number {
+  const explicit = toTimestamp(entry.reportDate);
+  if (explicit !== null) return explicit;
+
+  const fallback = toTimestamp(entry.savedAt) ?? toTimestamp(entry.createdAt) ?? Date.now();
+  if (entry.id && !warnedMissingReportDate.has(entry.id)) {
+    warnedMissingReportDate.add(entry.id);
+    console.warn(`Report ${entry.id} is missing reportDate; falling back to savedAt/createdAt.`);
+  }
+  return fallback;
+}
+
+export function resolveReportPanelName(entry: Pick<ReportHistoryEntry, 'title'> & Partial<Pick<ReportHistoryEntry, 'panelName'>>): string | null {
+  return resolvePanelName(entry.title, entry.panelName);
+}
+
 export async function fetchReportHistory(): Promise<ReportHistoryEntry[]> {
   const token = getAuthToken();
   if (!token) {
@@ -79,6 +125,9 @@ export async function fetchReportHistory(): Promise<ReportHistoryEntry[]> {
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
       createdAt: new Date(report.observed_at).getTime(),
+      savedAt: new Date(report.observed_at).getTime(),
+      reportDate: new Date(report.observed_at).getTime(),
+      panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: report.findings.map((f: any) => ({
         test_name: f.display_name,
         value: f.value_numeric ?? f.value_text ?? '',
@@ -98,6 +147,7 @@ export async function fetchReportHistory(): Promise<ReportHistoryEntry[]> {
 export async function createReportEntry(input: {
   title?: string | null;
   source_kind?: string;
+  observed_at?: string;
   findings: Array<{ test_name: string; value_numeric?: number | null; value_text?: string | null; unit?: string | null; reference_range?: string | null; flag?: string | null }>; 
 }): Promise<ReportHistoryEntry | null> {
   const token = getAuthToken();
@@ -114,6 +164,7 @@ export async function createReportEntry(input: {
       body: JSON.stringify({
         title: input.title,
         source_kind: input.source_kind || 'manual',
+        observed_at: input.observed_at,
         findings: input.findings.map((f) => ({
           test_name: f.test_name,
           value_numeric: f.value_numeric,
@@ -136,6 +187,9 @@ export async function createReportEntry(input: {
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
       createdAt: new Date(report.observed_at).getTime(),
+      savedAt: new Date(report.observed_at).getTime(),
+      reportDate: new Date(report.observed_at).getTime(),
+      panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: input.findings.map((f) => ({
         test_name: f.test_name,
         value: f.value_numeric ?? f.value_text ?? '',
@@ -174,6 +228,9 @@ export async function fetchReportById(reportId: string): Promise<ReportHistoryEn
       patientEmail: userEmail,
       title: report.title || 'Untitled Report',
       createdAt: new Date(report.observed_at).getTime(),
+      savedAt: new Date(report.observed_at).getTime(),
+      reportDate: new Date(report.observed_at).getTime(),
+      panelName: resolvePanelName(report.title, report.panel_name) ?? undefined,
       rows: report.findings.map((f: any) => ({
         test_name: f.display_name,
         value: f.value_numeric ?? f.value_text ?? '',
@@ -251,6 +308,9 @@ export function addReportToHistory(payload: Omit<ReportHistoryEntry, 'id' | 'cre
     unparsed: Array.isArray(payload.unparsed) ? payload.unparsed : [],
     id: `${payload.patientEmail}-${now}-${Math.random().toString(36).slice(2, 8)}`,
     createdAt: now,
+    savedAt: payload.savedAt ?? now,
+    reportDate: payload.reportDate ?? now,
+    panelName: payload.panelName ?? undefined,
   };
   saveAll([entry, ...existing]);
   return entry;

--- a/frontend/src/lib/reportTimeline.test.ts
+++ b/frontend/src/lib/reportTimeline.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildBiomarkerTimeline, parseReferenceRange } from './reportTimeline';
+
+describe('reportTimeline helpers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses common reference range strings', () => {
+    expect(parseReferenceRange('11-15')).toEqual({ low: 11, high: 15 });
+    expect(parseReferenceRange('<=200')).toEqual({ low: null, high: 200 });
+    expect(parseReferenceRange('>=5')).toEqual({ low: 5, high: null });
+  });
+
+  it('builds a multi-series timeline with aligned report dates', () => {
+    const reports = [
+      {
+        id: 'r1',
+        patientEmail: 'patient@example.com',
+        createdAt: new Date('2025-01-15T00:00:00Z').getTime(),
+        savedAt: new Date('2025-01-15T00:00:00Z').getTime(),
+        reportDate: new Date('2025-01-15T00:00:00Z').getTime(),
+        title: 'LFT',
+        rows: [
+          { test_name: 'ALT', value: 29, unit: 'U/L', reference_range: '11-15', flag: 'normal', confidence: 1 },
+          { test_name: 'AST', value: 28, unit: 'U/L', reference_range: '10-40', flag: 'normal', confidence: 1 },
+        ],
+        unparsed: [],
+      },
+      {
+        id: 'r2',
+        patientEmail: 'patient@example.com',
+        createdAt: new Date('2025-04-15T00:00:00Z').getTime(),
+        savedAt: new Date('2025-04-15T00:00:00Z').getTime(),
+        reportDate: new Date('2025-04-15T00:00:00Z').getTime(),
+        title: 'LFT',
+        rows: [
+          { test_name: 'ALT', value: 58, unit: 'U/L', reference_range: '11-15', flag: 'high', confidence: 1 },
+        ],
+        unparsed: [],
+      },
+    ] as any;
+
+    const result = buildBiomarkerTimeline(reports);
+
+    expect(result.reportDates).toEqual([
+      new Date('2025-01-15T00:00:00Z').getTime(),
+      new Date('2025-04-15T00:00:00Z').getTime(),
+    ]);
+    expect(result.series).toHaveLength(2);
+    const altSeries = result.series.find((item) => item.displayName === 'ALT');
+    expect(altSeries?.points).toHaveLength(2);
+    expect(altSeries?.points[1].y).toBe(58);
+    expect(result.reports[0].displayTitle).toContain('LFT');
+    expect(result.reports[0].displayTitle).toContain('2025');
+  });
+
+  it('falls back to savedAt and warns when reportDate is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const savedAt = new Date('2024-06-01T00:00:00Z').getTime();
+    const reports = [
+      {
+        id: 'r1',
+        patientEmail: 'patient@example.com',
+        createdAt: savedAt,
+        savedAt,
+        title: 'CBC',
+        rows: [{ test_name: 'Hgb', value: 12, unit: 'g/dL', reference_range: '11-15', flag: 'normal', confidence: 1 }],
+        unparsed: [],
+      },
+      {
+        id: 'r2',
+        patientEmail: 'patient@example.com',
+        createdAt: new Date('2024-07-01T00:00:00Z').getTime(),
+        savedAt: new Date('2024-07-01T00:00:00Z').getTime(),
+        reportDate: new Date('2024-07-01T00:00:00Z').getTime(),
+        title: 'CBC',
+        rows: [{ test_name: 'Hgb', value: 13, unit: 'g/dL', reference_range: '11-15', flag: 'normal', confidence: 1 }],
+        unparsed: [],
+      },
+    ] as any;
+
+    const result = buildBiomarkerTimeline(reports);
+
+    expect(result.reportDates[0]).toBe(savedAt);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing reportDate'));
+  });
+
+  it('excludes date-like rows even when they are numeric', () => {
+    const reports = [
+      {
+        id: 'r1',
+        patientEmail: 'patient@example.com',
+        createdAt: new Date('2025-01-15T00:00:00Z').getTime(),
+        reportDate: new Date('2025-01-15T00:00:00Z').getTime(),
+        title: 'Panel A',
+        rows: [
+          { test_name: 'Report Date', value: 20250115, unit: null, reference_range: null, flag: 'normal', confidence: 1 },
+          { test_name: 'ALT', value: 32, unit: 'U/L', reference_range: '10-40', flag: 'normal', confidence: 1 },
+        ],
+        unparsed: [],
+      },
+      {
+        id: 'r2',
+        patientEmail: 'patient@example.com',
+        createdAt: new Date('2025-02-15T00:00:00Z').getTime(),
+        reportDate: new Date('2025-02-15T00:00:00Z').getTime(),
+        title: 'Panel B',
+        rows: [
+          { test_name: 'Report Date', value: 20250215, unit: null, reference_range: null, flag: 'normal', confidence: 1 },
+          { test_name: 'ALT', value: 34, unit: 'U/L', reference_range: '10-40', flag: 'normal', confidence: 1 },
+        ],
+        unparsed: [],
+      },
+    ] as any;
+
+    const result = buildBiomarkerTimeline(reports);
+
+    expect(result.series.map((item) => item.displayName)).toEqual(['ALT']);
+  });
+});

--- a/frontend/src/lib/reportTimeline.ts
+++ b/frontend/src/lib/reportTimeline.ts
@@ -1,0 +1,204 @@
+import type { ParsedRow } from '@/types/ui';
+import type { ReportHistoryEntry } from './reportHistory';
+import { resolveReportDate, resolveReportPanelName } from './reportHistory';
+
+const PALETTE = ['#0d9488', '#f59e0b', '#6366f1', '#ec4899', '#10b981', '#f97316', '#8b5cf6', '#ef4444'];
+
+export type TimelinePoint = {
+  x: number;
+  y: number | null;
+  reportId: string;
+  reportDate: number;
+  unit: string | null;
+  flag: ParsedRow['flag'];
+  referenceRangeText: string | null;
+  reportLabel: string;
+};
+
+export type TimelineSeries = {
+  biomarkerKey: string;
+  displayName: string;
+  unit: string | null;
+  color: string;
+  points: TimelinePoint[];
+  referenceRangeText: string | null;
+  referenceRangeLow: number | null;
+  referenceRangeHigh: number | null;
+};
+
+export type TimelineReportCard = {
+  id: string;
+  title: string;
+  displayTitle: string;
+  reportDate: number;
+  reportDateLabel: string;
+  accentColor: string;
+  testCount: number;
+  hasInterpretation: boolean;
+};
+
+function formatReportDate(value: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function normalizeKey(value: string) {
+  return value.trim().toLowerCase();
+}
+
+const NON_QUANT_MARKER_NAME = /\b(date|dob|time|collected|collection|reported|specimen|sample\s*date|accession|patient\s*id|mrn)\b/i;
+
+function isNumericBiomarkerRow(row: ParsedRow): boolean {
+  if (typeof row.value !== 'number' || !Number.isFinite(row.value)) return false;
+  if (NON_QUANT_MARKER_NAME.test(row.test_name || '')) return false;
+  return true;
+}
+
+export function parseReferenceRange(referenceRange?: string | null): { low: number | null; high: number | null } {
+  if (!referenceRange) return { low: null, high: null };
+
+  const text = referenceRange.trim();
+  if (!text) return { low: null, high: null };
+
+  const rangeMatch = text.match(/(-?\d+(?:\.\d+)?)\s*[-–]\s*(-?\d+(?:\.\d+)?)/);
+  if (rangeMatch) {
+    return { low: Number(rangeMatch[1]), high: Number(rangeMatch[2]) };
+  }
+
+  const lessThanMatch = text.match(/<=?\s*(-?\d+(?:\.\d+)?)/);
+  if (lessThanMatch) {
+    return { low: null, high: Number(lessThanMatch[1]) };
+  }
+
+  const greaterThanMatch = text.match(/>=?\s*(-?\d+(?:\.\d+)?)/);
+  if (greaterThanMatch) {
+    return { low: Number(greaterThanMatch[1]), high: null };
+  }
+
+  return { low: null, high: null };
+}
+
+export function buildBiomarkerTimeline(reports: ReportHistoryEntry[]): {
+  reports: TimelineReportCard[];
+  series: TimelineSeries[];
+  reportDates: number[];
+} {
+  const sortedReports = [...reports].sort((a, b) => resolveReportDate(a) - resolveReportDate(b));
+  const reportDates = sortedReports.map((report) => resolveReportDate(report));
+
+  const biomarkerMap = new Map<string, {
+    biomarkerKey: string;
+    displayName: string;
+    unit: string | null;
+    pointsByReportId: Map<string, TimelinePoint>;
+    referenceRangeText: string | null;
+    referenceRangeLow: number | null;
+    referenceRangeHigh: number | null;
+  }>();
+
+  sortedReports.forEach((report, reportIndex) => {
+    const reportDate = resolveReportDate(report);
+    const reportDisplayLabel = formatReportDate(reportDate);
+
+    const numericRows = report.rows.filter(isNumericBiomarkerRow);
+    numericRows.forEach((row) => {
+      const biomarkerKey = normalizeKey(row.test_name);
+      const existing = biomarkerMap.get(biomarkerKey);
+      const referenceRangeText = row.reference_range ?? null;
+      const parsedRange = parseReferenceRange(referenceRangeText);
+      const point: TimelinePoint = {
+        x: reportDate,
+        y: typeof row.value === 'number' ? row.value : null,
+        reportId: report.id,
+        reportDate,
+        unit: row.unit ?? null,
+        flag: row.flag ?? null,
+        referenceRangeText,
+        reportLabel: report.title || reportDisplayLabel,
+      };
+
+      if (existing) {
+        existing.pointsByReportId.set(report.id, point);
+        if (!existing.referenceRangeText && referenceRangeText) {
+          existing.referenceRangeText = referenceRangeText;
+          existing.referenceRangeLow = parsedRange.low;
+          existing.referenceRangeHigh = parsedRange.high;
+        }
+        if (!existing.unit && point.unit) {
+          existing.unit = point.unit;
+        }
+        return;
+      }
+
+      biomarkerMap.set(biomarkerKey, {
+        biomarkerKey,
+        displayName: row.test_name,
+        unit: row.unit ?? null,
+        pointsByReportId: new Map([[report.id, point]]),
+        referenceRangeText,
+        referenceRangeLow: parsedRange.low,
+        referenceRangeHigh: parsedRange.high,
+      });
+    });
+
+  });
+
+  const series = Array.from(biomarkerMap.values())
+    .sort((a, b) => a.displayName.localeCompare(b.displayName))
+    .map((item, index) => ({
+      biomarkerKey: item.biomarkerKey,
+      displayName: item.displayName,
+      unit: item.unit,
+      color: PALETTE[index % PALETTE.length],
+      points: sortedReports.map((report) => {
+        const reportDate = resolveReportDate(report);
+        const point = item.pointsByReportId.get(report.id);
+        if (point) {
+          return point;
+        }
+        return {
+          x: reportDate,
+          y: null,
+          reportId: report.id,
+          reportDate,
+          unit: item.unit,
+          flag: null,
+          referenceRangeText: null,
+          reportLabel: report.title || formatReportDate(reportDate),
+        };
+      }),
+      referenceRangeText: item.referenceRangeText,
+      referenceRangeLow: item.referenceRangeLow,
+      referenceRangeHigh: item.referenceRangeHigh,
+    }));
+
+  const reportCards: TimelineReportCard[] = sortedReports.map((report, index) => {
+    const reportDate = resolveReportDate(report);
+    const reportDisplayDate = formatReportDate(reportDate);
+    const panelName = resolveReportPanelName(report);
+    const title = panelName ? `${panelName} — ${reportDisplayDate}` : reportDisplayDate;
+    const firstNumericRow = report.rows.find(isNumericBiomarkerRow);
+    const seriesIndex = firstNumericRow ? series.findIndex((item) => normalizeKey(item.displayName) === normalizeKey(firstNumericRow.test_name)) : -1;
+    const accentColor = seriesIndex >= 0 ? series[seriesIndex].color : PALETTE[index % PALETTE.length];
+
+    return {
+      id: report.id,
+      title: report.title,
+      displayTitle: title,
+      reportDate,
+      reportDateLabel: reportDisplayDate,
+      accentColor,
+      testCount: report.rows.length,
+      hasInterpretation: Boolean(report.interpretation),
+    };
+  });
+
+  return {
+    reports: reportCards,
+    series,
+    reportDates,
+  };
+}

--- a/frontend/src/lib/reportTrends.test.ts
+++ b/frontend/src/lib/reportTrends.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchReportTrends } from './reportTrends';
+
+describe('reportTrends helper', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('throws when user is not authenticated', async () => {
+    await expect(fetchReportTrends('report-1')).rejects.toThrow('User is not authenticated.');
+  });
+
+  it('calls trends endpoint with bearer token and returns payload', async () => {
+    localStorage.setItem('reportx_session', JSON.stringify({ accessToken: 'token-123' }));
+    const payload = {
+      report_id: 'report-1',
+      subject_user_id: 'user-1',
+      trends: [
+        {
+          biomarker_key: 'hemoglobin',
+          display_name: 'Hemoglobin',
+          unit: 'g/dL',
+          direction: 'improving',
+          trend_note: 'Hemoglobin trend appears to be improving compared with prior reports.',
+          sparkline: [
+            {
+              report_id: 'report-0',
+              observed_at: '2026-04-01T00:00:00Z',
+              value: 16.2,
+              unit: 'g/dL',
+              flag: 'high',
+            },
+          ],
+        },
+      ],
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await fetchReportTrends('report-1');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/reports/report-1/trends',
+      { headers: { Authorization: 'Bearer token-123' } },
+    );
+    expect(result).toEqual(payload);
+  });
+
+  it('throws readable error when backend returns non-2xx', async () => {
+    localStorage.setItem('reportx_session', JSON.stringify({ accessToken: 'token-123' }));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Forbidden', {
+        status: 403,
+      }),
+    );
+
+    await expect(fetchReportTrends('report-1')).rejects.toThrow(
+      'Unexpected response when fetching report trends: 403 Forbidden',
+    );
+  });
+});

--- a/frontend/src/lib/reportTrends.ts
+++ b/frontend/src/lib/reportTrends.ts
@@ -1,0 +1,69 @@
+export type TrendDirection = 'improving' | 'stable' | 'worsening';
+
+export type ReportTrendPoint = {
+  report_id: string;
+  observed_at: string;
+  value: number;
+  unit: string | null;
+  flag: 'low' | 'high' | 'normal' | 'abnormal' | 'unknown';
+};
+
+export type BiomarkerTrend = {
+  biomarker_key: string;
+  display_name: string;
+  unit: string | null;
+  direction: TrendDirection;
+  trend_note: string;
+  sparkline: ReportTrendPoint[];
+};
+
+export type ReportTrendsResponse = {
+  report_id: string;
+  subject_user_id: string;
+  trends: BiomarkerTrend[];
+};
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+function safeLocalStorageGet(key: string): string | null {
+  if (!isBrowser) return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function getStoredSession(): { accessToken?: string } | null {
+  const raw = safeLocalStorageGet('reportx_session');
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function getAuthToken(): string | null {
+  return getStoredSession()?.accessToken ?? null;
+}
+
+export async function fetchReportTrends(reportId: string): Promise<ReportTrendsResponse> {
+  const token = getAuthToken();
+  if (!token) {
+    throw new Error('User is not authenticated.');
+  }
+  if (!reportId?.trim()) {
+    throw new Error('reportId is required');
+  }
+
+  const response = await fetch(`${BACKEND_URL}/api/v1/reports/${encodeURIComponent(reportId)}/trends`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(`Unexpected response when fetching report trends: ${response.status} ${errorText}`);
+  }
+  return response.json();
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,49 @@
 import '@testing-library/jest-dom/vitest';
+
+const createCanvasContextMock = (canvas: HTMLCanvasElement) => ({
+	canvas,
+	clearRect: () => undefined,
+	fillRect: () => undefined,
+	strokeRect: () => undefined,
+	beginPath: () => undefined,
+	closePath: () => undefined,
+	moveTo: () => undefined,
+	lineTo: () => undefined,
+	bezierCurveTo: () => undefined,
+	quadraticCurveTo: () => undefined,
+	arc: () => undefined,
+	rect: () => undefined,
+	fill: () => undefined,
+	stroke: () => undefined,
+	save: () => undefined,
+	restore: () => undefined,
+	translate: () => undefined,
+	scale: () => undefined,
+	rotate: () => undefined,
+	setTransform: () => undefined,
+	resetTransform: () => undefined,
+	drawImage: () => undefined,
+	measureText: (text: unknown) => ({ width: String(text ?? '').length * 8 }),
+	setLineDash: () => undefined,
+	getLineDash: () => [],
+	fillText: () => undefined,
+	strokeText: () => undefined,
+	createLinearGradient: () => ({ addColorStop: () => undefined }),
+	createRadialGradient: () => ({ addColorStop: () => undefined }),
+	createPattern: () => null,
+});
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+	value(this: HTMLCanvasElement) {
+		return createCanvasContextMock(this);
+	},
+});
+
+class ResizeObserverMock {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+(globalThis as typeof globalThis & { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver = ResizeObserverMock;
+


### PR DESCRIPTION
This PR implements longitudinal trend analysis, improves how trend data is fetched, makes translation calls more efficient, stores the actual report date from uploaded reports, and updates My Report History to a clearer table layout.

### What changed
- Added trend support end-to-end (backend + frontend) so report trend data is available and shown in the app.
- Switched translation behavior to lazy, on-demand calls to reduce extra processing and improve responsiveness.
- Extracted Report Date from uploaded report content and saved it as the clinical observation date.
- Used the saved report date in trend views instead of upload time.
- Filtered trend charts to numeric biomarkers only, so non-numeric/date-like rows do not appear as chart points.
- Replaced report history cards with a compact, sortable table for faster scanning, with mobile-friendly condensed rows.

### Why
Trends are now based on the real lab test date.
Charts are cleaner and easier to read.
Report history is quicker to scan and compare.

### Included commits
b9fd384 — trends API/client + lazy translation
78e49ac — persist report date + numeric-only biomarker trends
98adecb — compact sortable report history table