### PR TITLE
Question for clinician

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .routers.health import router as health_router
 from .routers.interpret import router as interpret_router
 from .routers.parse import router as parse_router
 from .routers.reports import router as reports_router
+from .routers.threads import router as threads_router
 from .routers.translate import router as translate_router
 
 
@@ -178,6 +179,7 @@ def create_app() -> FastAPI:
     app.include_router(parse_router, prefix="/api/v1")
     app.include_router(interpret_router, prefix="/api/v1")
     app.include_router(reports_router, prefix="/api/v1")
+    app.include_router(threads_router, prefix="/api/v1")
     app.include_router(translate_router, prefix="/api/v1")
 
     @app.get("/", include_in_schema=False)

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, UTC
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.db.models import (
+    ConversationThread,
+    MessageKind,
+    Report,
+    ThreadMessage,
+    ThreadParticipant,
+    User,
+)
+from app.db.session import get_db_session
+from app.dependencies.auth import AuthContext, get_current_auth_context
+from app.dependencies.reports import get_accessible_report
+from app.services.questions import generate_questions
+
+router = APIRouter(tags=["threads"])
+
+
+class QuestionPromptsResponse(BaseModel):
+    prompts: list[str]
+
+
+@router.get("/reports/{report_id}/question-prompts", response_model=QuestionPromptsResponse)
+async def get_question_prompts(
+    report: Report = Depends(get_accessible_report),
+    auth: AuthContext = Depends(get_current_auth_context),
+) -> QuestionPromptsResponse:
+    prompts, _ = await generate_questions(report.findings)
+    return QuestionPromptsResponse(prompts=prompts)
+
+
+class ThreadMessageOut(BaseModel):
+    id: str
+    author_user_id: str
+    author_name: str
+    kind: str
+    body: str
+    created_at: datetime
+
+
+class ConversationThreadOut(BaseModel):
+    id: str
+    report_id: str | None
+    subject_user_id: str
+    title: str | None
+    status: str
+    created_at: datetime
+    messages: list[ThreadMessageOut] = []
+
+
+class CreateThreadRequest(BaseModel):
+    title: str | None = None
+    initial_message: str
+
+
+@router.get("/reports/{report_id}/threads", response_model=list[ConversationThreadOut])
+async def list_report_threads(
+    report: Report = Depends(get_accessible_report),
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[ConversationThreadOut]:
+    stmt = (
+        select(ConversationThread)
+        .where(ConversationThread.report_id == report.id)
+        .order_by(ConversationThread.created_at.desc())
+        .options(selectinload(ConversationThread.messages).selectinload(ThreadMessage.author_user))
+    )
+    result = await session.scalars(stmt)
+    threads = result.all()
+
+    out = []
+    for thread in threads:
+        messages = sorted(thread.messages, key=lambda m: m.created_at)
+        msgs_out = [
+            ThreadMessageOut(
+                id=m.id,
+                author_user_id=m.author_user_id,
+                author_name=m.author_user.display_name if m.author_user else "Unknown",
+                kind=m.kind.value,
+                body=m.body,
+                created_at=m.created_at,
+            )
+            for m in messages
+        ]
+        out.append(
+            ConversationThreadOut(
+                id=thread.id,
+                report_id=thread.report_id,
+                subject_user_id=thread.subject_user_id,
+                title=thread.title,
+                status=thread.status.value,
+                created_at=thread.created_at,
+                messages=msgs_out,
+            )
+        )
+    return out
+
+
+@router.post("/reports/{report_id}/threads", response_model=ConversationThreadOut, status_code=status.HTTP_201_CREATED)
+async def create_thread(
+    payload: CreateThreadRequest,
+    report: Report = Depends(get_accessible_report),
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> ConversationThreadOut:
+    thread = ConversationThread(
+        subject_user_id=report.subject_user_id,
+        created_by_user_id=auth.user.id,
+        report_id=report.id,
+        title=payload.title or "Questions for Clinician",
+    )
+    session.add(thread)
+    await session.flush()
+
+    participant = ThreadParticipant(thread_id=thread.id, user_id=auth.user.id)
+    session.add(participant)
+
+    message = ThreadMessage(
+        thread_id=thread.id,
+        author_user_id=auth.user.id,
+        kind=MessageKind.TEXT,
+        body=payload.initial_message,
+    )
+    session.add(message)
+    await session.commit()
+    await session.refresh(thread)
+
+    return ConversationThreadOut(
+        id=thread.id,
+        report_id=thread.report_id,
+        subject_user_id=thread.subject_user_id,
+        title=thread.title,
+        status=thread.status.value,
+        created_at=thread.created_at,
+        messages=[
+            ThreadMessageOut(
+                id=message.id,
+                author_user_id=message.author_user_id,
+                author_name=auth.user.display_name,
+                kind=message.kind.value,
+                body=message.body,
+                created_at=message.created_at,
+            )
+        ],
+    )
+
+
+class AddMessageRequest(BaseModel):
+    body: str | None = None
+    template_payload: dict[str, Any] | None = None
+
+
+@router.post("/threads/{thread_id}/messages", response_model=ThreadMessageOut, status_code=status.HTTP_201_CREATED)
+async def add_message(
+    thread_id: str,
+    payload: AddMessageRequest,
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> ThreadMessageOut:
+    thread = await session.scalar(select(ConversationThread).where(ConversationThread.id == thread_id))
+    if not thread:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Thread not found")
+
+    if payload.template_payload:
+        kind = MessageKind.TEMPLATE
+        body = json.dumps(payload.template_payload)
+    elif payload.body:
+        kind = MessageKind.TEXT
+        body = payload.body
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Must provide body or template_payload")
+
+    message = ThreadMessage(
+        thread_id=thread.id,
+        author_user_id=auth.user.id,
+        kind=kind,
+        body=body,
+    )
+    session.add(message)
+    
+    participant = await session.scalar(
+        select(ThreadParticipant).where(
+            ThreadParticipant.thread_id == thread.id,
+            ThreadParticipant.user_id == auth.user.id
+        )
+    )
+    if not participant:
+        session.add(ThreadParticipant(thread_id=thread.id, user_id=auth.user.id))
+
+    await session.commit()
+    await session.refresh(message)
+
+    return ThreadMessageOut(
+        id=message.id,
+        author_user_id=message.author_user_id,
+        author_name=auth.user.display_name,
+        kind=message.kind.value,
+        body=message.body,
+        created_at=message.created_at,
+    )

--- a/backend/app/services/questions.py
+++ b/backend/app/services/questions.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from app.db.models import FindingFlag, ReportFinding
+from app.services.llm import _call_openai_chat, _call_openai_responses, _resolve_model, _timeout_seconds
+
+logger = logging.getLogger("reportrx.backend")
+
+def _fallback_questions(flagged_findings: list[ReportFinding]) -> list[str]:
+    """Fallback list of questions if LLM fails or is unavailable."""
+    if not flagged_findings:
+        return [
+            "Are there any trends in my lab results I should be aware of?",
+            "Do I need to make any changes to my diet, exercise, or medications?",
+            "When should I have these or other tests done again?"
+        ]
+    
+    # Extract names for flagged items
+    names = [f.display_name for f in flagged_findings if f.flag in {FindingFlag.HIGH, FindingFlag.LOW, FindingFlag.ABNORMAL}]
+    if not names:
+        names = [f.display_name for f in flagged_findings][:2]
+        
+    names_str = ", ".join(names[:2])
+    if len(names) > 2:
+        names_str += " and others"
+        
+    return [
+        f"What might be causing my abnormal results for {names_str}?",
+        f"Do my current symptoms fit with these findings for {names_str}?",
+        "Are there immediate steps or new medications needed based on these flags?"
+    ]
+
+def _build_prompt(flagged_findings: list[ReportFinding]) -> str:
+    simplified = [
+        {
+            "test_name": f.display_name,
+            "value": f.value_text or str(f.value_numeric),
+            "unit": f.unit,
+            "flag": f.flag.value
+        }
+        for f in flagged_findings
+    ]
+    
+    instructions = (
+        "Based on the following flagged lab results, generate exactly 3 patient-friendly questions "
+        "the patient should ask their clinician. The questions should cover: "
+        "1. Symptoms or causes relative to the abnormal findings, "
+        "2. Level of concern or urgency, "
+        "3. Recommended next steps or timeline for follow-up.\n"
+        "Return the output as a valid JSON array of strings, with no additional text or Markdown formatting.\n\n"
+        "Example Output:\n"
+        '["What could be causing my elevated glucose?", "Should I be concerned about my low iron?", "When should I retest?"]\n\n'
+    )
+    return instructions + "RESULTS:\n" + json.dumps(simplified, ensure_ascii=False)
+
+async def generate_questions(findings: list[ReportFinding]) -> tuple[list[str], dict[str, Any]]:
+    start = time.perf_counter()
+    meta: dict[str, Any] = {"llm": "none", "attempts": 0}
+    meta["model"] = _resolve_model(os.getenv("OPENAI_MODEL", "gpt-5"))
+    meta["endpoint"] = "unknown"
+    
+    flagged = [f for f in findings if f.flag in {FindingFlag.HIGH, FindingFlag.LOW, FindingFlag.ABNORMAL}]
+    
+    # If no flagged findings, return generic fallback immediately to save LLM cost
+    if not flagged:
+        meta["ok"] = True
+        meta["duration_ms"] = int((time.perf_counter() - start) * 1000)
+        return _fallback_questions([]), meta
+
+    prompt = _build_prompt(flagged[:10])  # limit to 10 flags to fit context
+    
+    try:
+        use_responses = meta["model"].startswith("gpt-5") or os.getenv("OPENAI_USE_RESPONSES", "0") in {"1", "true", "True"}
+        meta["llm"] = "openai"
+        meta["attempts"] = 1
+        meta["endpoint"] = "responses" if use_responses else "chat.completions"
+        
+        raw: str
+        call: dict[str, Any]
+        if use_responses:
+            try:
+                raw, call = await _call_openai_responses(prompt, timeout_s=_timeout_seconds("responses"))
+            except Exception:
+                meta["endpoint"] = "chat.completions"
+                raw, call = await _call_openai_chat(prompt, timeout_s=_timeout_seconds("chat"))
+        else:
+            raw, call = await _call_openai_chat(prompt, timeout_s=_timeout_seconds("chat"))
+            
+        text_out = (raw or "").strip()
+        
+        # Try to parse the JSON array
+        questions: list[str] = []
+        try:
+            # Clean up markdown code blocks if present
+            if text_out.startswith("```json"):
+                text_out = text_out[7:]
+            if text_out.endswith("```"):
+                text_out = text_out[:-3]
+            text_out = text_out.strip()
+            
+            parsed = json.loads(text_out)
+            if isinstance(parsed, list) and all(isinstance(i, str) for i in parsed):
+                questions = parsed
+        except Exception:
+            pass
+            
+        if len(questions) < 2:
+            # Fallback if parsing failed or didn't provide enough
+            questions = _fallback_questions(flagged)
+
+        meta["ok"] = True
+        if call:
+            if "usage" in call:
+                meta["usage"] = call["usage"]
+        logger.info({"event": "llm_generate_questions", "ok": True, "attempts": meta["attempts"]})
+        
+        meta["duration_ms"] = int((time.perf_counter() - start) * 1000)
+        return questions[:3], meta
+
+    except Exception as e:
+        logger.exception("Failed to generate questions")
+        meta["ok"] = False
+        meta["error"] = str(e)
+        meta["duration_ms"] = int((time.perf_counter() - start) * 1000)
+        return _fallback_questions(flagged), meta

--- a/backend/tests/test_threads.py
+++ b/backend/tests/test_threads.py
@@ -1,0 +1,91 @@
+import pytest
+import httpx
+from datetime import datetime, UTC
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.db.models import Report, ReportSourceKind, ReportSharingMode, User, ConversationThread, ThreadMessage, ThreadStatus, MessageKind
+
+@pytest.fixture
+async def sample_report(db_session: AsyncSession, mock_user: User) -> Report:
+    report = Report(
+        subject_user_id=mock_user.id,
+        created_by_user_id=mock_user.id,
+        title="Test Labs",
+        source_kind=ReportSourceKind.MANUAL,
+        sharing_mode=ReportSharingMode.PRIVATE,
+        observed_at=datetime.now(UTC),
+    )
+    db_session.add(report)
+    await db_session.commit()
+    await db_session.refresh(report)
+    return report
+
+@pytest.mark.asyncio
+async def test_create_and_list_threads(
+    async_client: httpx.AsyncClient, 
+    sample_report: Report,
+    auth_headers: dict[str, str]
+):
+    # 1. Create a thread
+    resp = await async_client.post(
+        f"/api/v1/reports/{sample_report.id}/threads",
+        json={"initial_message": "What does my glucose mean?", "title": "Glucose question"},
+        headers=auth_headers
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "Glucose question"
+    assert len(data["messages"]) == 1
+    thread_id = data["id"]
+    
+    # 2. Add clinician template message
+    resp = await async_client.post(
+        f"/api/v1/threads/{thread_id}/messages",
+        json={
+            "template_payload": {
+                "meaning": "Your glucose is slightly high but ok.",
+                "urgency": "routine",
+                "action": "Monitor diet."
+            }
+        },
+        headers=auth_headers
+    )
+    assert resp.status_code == 201
+    msg_data = resp.json()
+    assert msg_data["kind"] == "template"
+    
+    # 3. Add text response
+    resp = await async_client.post(
+        f"/api/v1/threads/{thread_id}/messages",
+        json={"body": "Thank you doctor!"},
+        headers=auth_headers
+    )
+    assert resp.status_code == 201
+    msg_data = resp.json()
+    assert msg_data["kind"] == "text"
+    assert msg_data["body"] == "Thank you doctor!"
+    
+    # 4. List threads
+    resp = await async_client.get(
+        f"/api/v1/reports/{sample_report.id}/threads",
+        headers=auth_headers
+    )
+    assert resp.status_code == 200
+    threads = resp.json()
+    assert len(threads) == 1
+    assert len(threads[0]["messages"]) == 3
+
+@pytest.mark.asyncio
+async def test_get_question_prompts(
+    async_client: httpx.AsyncClient, 
+    sample_report: Report,
+    auth_headers: dict[str, str]
+):
+    resp = await async_client.get(
+        f"/api/v1/reports/{sample_report.id}/question-prompts",
+        headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "prompts" in data
+    assert isinstance(data["prompts"], list)
+    assert len(data["prompts"]) >= 2

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -661,19 +661,52 @@ button:hover {
   border-radius: 8px;
 }
 
-/* Print styles */
+/* Print styles — FR13 Doctor-Ready PDF Summary */
 @media print {
-  body {
-    background: #fff;
-    color: #000;
-  }
-  .no-print {
+  /* Hide all page chrome */
+  body > *:not(#__next):not(#doctor-summary-print-target) {
     display: none !important;
   }
-  .doctor-summary {
-    border: none;
-    box-shadow: none;
+
+  /* Hide everything inside Next.js root EXCEPT the print target wrapper */
+  #__next > *,
+  header, nav, footer,
+  .header, .footer, .no-print,
+  [class*="navbar"], [class*="sidebar"] {
+    display: none !important;
   }
+
+  /* Reveal and reset the print target */
+  #doctor-summary-print-target {
+    display: block !important;
+  }
+
+  /* The summary document itself */
+  .doctor-summary-print {
+    display: block !important;
+    font-family: 'Inter', Arial, sans-serif;
+    font-size: 11pt;
+    color: #000;
+    background: #fff;
+    padding: 1.5cm 2cm;
+    margin: 0;
+    max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  /* Force page break to have all content visible */
+  @page {
+    size: A4 portrait;
+    margin: 1.5cm 2cm;
+  }
+
+  /* Tables should not break mid-row */
+  table { page-break-inside: auto; }
+  tr { page-break-inside: avoid; }
+
+  /* Remove link underlines artifacts in print */
+  a { text-decoration: none; color: inherit; }
 }
 
 @keyframes spin {

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useAuth } from '@/store/authStore';
 import { ProtectedView } from '@/components/ProtectedView';
 import { fetchReportById, updateReportInHistory } from '@/lib/reportHistory';
 import type { ReportHistoryEntry, SharingPreferences } from '@/lib/reportHistory';
 import { PatientQuestions } from '@/components/PatientQuestions';
-import { ThreadView } from '@/components/ThreadView';
+import { ThreadView, ConversationThread } from '@/components/ThreadView';
+import { DoctorSummaryDocument, type SummaryFinding, type SummaryThread } from '@/components/DoctorSummaryDocument';
 function formatDate(ts: number) {
   return new Date(ts).toLocaleString();
 }
@@ -23,6 +24,9 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
   const [report, setReport] = useState<ReportHistoryEntry | undefined>(undefined);
   const [sharingPreferences, setSharingPreferences] = useState<SharingPreferences>(defaultSharingPreferences);
   const [statusMessage, setStatusMessage] = useState('');
+  // FR13 state
+  const [includeSummaryPDF, setIncludeSummaryPDF] = useState(false);
+  const [threads, setThreads] = useState<ConversationThread[]>([]);
 
   useEffect(() => {
     async function loadReport() {
@@ -178,10 +182,73 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
 
   const interpretation = report.interpretation;
 
+  // --- FR13: build data for DoctorSummaryDocument ---
+  const accessToken = (() => {
+    if (typeof window === 'undefined') return '';
+    const stored = localStorage.getItem('reportx_session');
+    if (!stored) return '';
+    try { return JSON.parse(stored)?.accessToken || ''; } catch { return ''; }
+  })();
+
+  const allFindingsForPDF: SummaryFinding[] = report.rows.map((r) => ({
+    test_name: r.test_name,
+    value: String(r.value ?? ''),
+    unit: r.unit || undefined,
+    flag: r.flag || 'unknown',
+    reference_range: r.reference_range || undefined,
+  }));
+
+  const flaggedFindings = allFindingsForPDF.filter(
+    (f) => ['high', 'low', 'abnormal'].includes(f.flag.toLowerCase())
+  );
+
+  const threadSummaries: SummaryThread[] = threads.map((t) => ({
+    title: t.title,
+    patientQuestions: t.messages
+      .filter((m) => m.kind === 'text')
+      .map((m) => m.body)
+      .slice(0, 5),
+  }));
+
+  const handleExportPDF = () => {
+    window.print();
+  };
+
+  const handleShareWithPDF = async () => {
+    await updateShare();
+    if (includeSummaryPDF) {
+      setTimeout(() => window.print(), 400);
+    }
+  };
+
   return (
     <ProtectedView>
+      {/* FR13 — hidden print-only wrapper, revealed only via @media print */}
+      <div id="doctor-summary-print-target" style={{ display: 'none' }}>
+        <DoctorSummaryDocument
+          reportTitle={report.title || 'Lab Results Summary'}
+          reportDate={formatDate(report.createdAt)}
+          patientName={user?.displayName || user?.email || 'Patient'}
+          flaggedFindings={flaggedFindings}
+          allFindings={allFindingsForPDF}
+          interpretationSummary={interpretation?.summary}
+          trendNotes={undefined}
+          threads={threadSummaries}
+        />
+      </div>
+
       <section className="stack">
-        <h1>{report.title || 'Report Detail'}</h1>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+          <h1 style={{ margin: 0 }}>{report.title || 'Report Detail'}</h1>
+          <button
+            id="export-doctor-summary-btn"
+            className="nav-btn nav-btn-primary"
+            onClick={handleExportPDF}
+            title="Export a doctor-ready one-page PDF summary — generated locally, never stored on server"
+          >
+            📄 Export Doctor Summary
+          </button>
+        </div>
         <p>Saved: {formatDate(report.createdAt)}</p>
         <p>Rows: {report.rows.length}</p>
         <p>Interpretation: {interpretation ? 'Available' : 'Not completed yet'}</p>
@@ -204,15 +271,16 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
           </div>
         )}
 
-        <PatientQuestions 
-          reportId={report.id} 
-          accessToken={localStorage.getItem('reportx_session') ? JSON.parse(localStorage.getItem('reportx_session')!)?.accessToken || '' : ''} 
-          onThreadCreated={() => {}} 
+        <PatientQuestions
+          reportId={report.id}
+          accessToken={accessToken}
+          onThreadCreated={() => {}}
         />
 
-        <ThreadView 
-          reportId={report.id} 
-          accessToken={localStorage.getItem('reportx_session') ? JSON.parse(localStorage.getItem('reportx_session')!)?.accessToken || '' : ''} 
+        <ThreadView
+          reportId={report.id}
+          accessToken={accessToken}
+          onThreadsLoaded={setThreads}
         />
 
         <div className="card">
@@ -245,7 +313,21 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
               onChange={(e) => setSharingPreferences({ ...sharingPreferences, expiresAt: new Date(e.target.value).getTime() })}
             />
           </div>
-          <button className="nav-btn nav-btn-primary" onClick={updateShare}>{sharingPreferences.active ? 'Update Share' : 'Start Sharing'}</button>
+          {/* FR13 — include doctor-ready summary PDF when sharing */}
+          <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', background: '#f0fdf4', padding: '0.75rem', borderRadius: '8px', border: '1px solid #bbf7d0', marginBottom: '0.5rem' }}>
+            <input
+              id="include-summary-pdf"
+              type="checkbox"
+              checked={includeSummaryPDF}
+              onChange={(e) => setIncludeSummaryPDF(e.target.checked)}
+              style={{ width: '1rem', height: '1rem', cursor: 'pointer' }}
+            />
+            <label htmlFor="include-summary-pdf" style={{ cursor: 'pointer', fontSize: '0.9rem', color: '#15803d', fontWeight: 500 }}>
+              📄 Also download Doctor-Ready Summary PDF
+              <span style={{ display: 'block', fontSize: '0.75rem', color: '#6b7280', fontWeight: 400 }}>Generated locally in your browser — never stored on server</span>
+            </label>
+          </div>
+          <button id="share-report-btn" className="nav-btn nav-btn-primary" onClick={handleShareWithPDF}>{sharingPreferences.active ? 'Update Share' : 'Start Sharing'}</button>
           {sharingPreferences.active && <button className="nav-btn nav-btn-danger" onClick={revokeShare} style={{ marginLeft: '0.5rem' }}>Revoke</button>}
           {statusMessage && <p>{statusMessage}</p>}
         </div>

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -5,7 +5,8 @@ import { useAuth } from '@/store/authStore';
 import { ProtectedView } from '@/components/ProtectedView';
 import { fetchReportById, updateReportInHistory } from '@/lib/reportHistory';
 import type { ReportHistoryEntry, SharingPreferences } from '@/lib/reportHistory';
-
+import { PatientQuestions } from '@/components/PatientQuestions';
+import { ThreadView } from '@/components/ThreadView';
 function formatDate(ts: number) {
   return new Date(ts).toLocaleString();
 }
@@ -202,6 +203,17 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
             <p>{interpretation.summary}</p>
           </div>
         )}
+
+        <PatientQuestions 
+          reportId={report.id} 
+          accessToken={localStorage.getItem('reportx_session') ? JSON.parse(localStorage.getItem('reportx_session')!)?.accessToken || '' : ''} 
+          onThreadCreated={() => {}} 
+        />
+
+        <ThreadView 
+          reportId={report.id} 
+          accessToken={localStorage.getItem('reportx_session') ? JSON.parse(localStorage.getItem('reportx_session')!)?.accessToken || '' : ''} 
+        />
 
         <div className="card">
           <h2>Sharing Preferences</h2>

--- a/frontend/src/app/reports/__tests__/DoctorSummary.test.tsx
+++ b/frontend/src/app/reports/__tests__/DoctorSummary.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { DoctorSummaryDocument } from '../../../../components/DoctorSummaryDocument';
+
+describe('DoctorSummaryDocument — FR13', () => {
+  const baseProps = {
+    reportTitle: 'Annual Blood Panel',
+    reportDate: '2026-04-05',
+    patientName: 'Jane Doe',
+    flaggedFindings: [
+      { test_name: 'Glucose', value: '130', unit: 'mg/dL', flag: 'high', reference_range: '70-100' },
+      { test_name: 'Hemoglobin', value: '10.2', unit: 'g/dL', flag: 'low', reference_range: '12-17' },
+    ],
+    allFindings: [
+      { test_name: 'Glucose', value: '130', unit: 'mg/dL', flag: 'high', reference_range: '70-100' },
+      { test_name: 'Hemoglobin', value: '10.2', unit: 'g/dL', flag: 'low', reference_range: '12-17' },
+      { test_name: 'Sodium', value: '138', unit: 'mEq/L', flag: 'normal', reference_range: '135-145' },
+    ],
+    interpretationSummary: 'Elevated glucose may indicate pre-diabetes. Low hemoglobin is consistent with mild anemia.',
+    trendNotes: 'Glucose trending up over last 3 visits.',
+    threads: [
+      {
+        title: 'Blood sugar questions',
+        patientQuestions: [
+          'What does high glucose mean for me?',
+          'Should I change my diet?',
+        ],
+      },
+    ],
+  };
+
+  it('renders the report title and patient name', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText('Annual Blood Panel')).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+  });
+
+  it('renders flagged findings in the table', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText('Glucose')).toBeInTheDocument();
+    expect(screen.getByText('Hemoglobin')).toBeInTheDocument();
+    expect(screen.getByText('HIGH')).toBeInTheDocument();
+    expect(screen.getByText('LOW')).toBeInTheDocument();
+  });
+
+  it('renders the AI interpretation summary', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText(/Elevated glucose may indicate pre-diabetes/)).toBeInTheDocument();
+  });
+
+  it('renders trend notes when provided', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText(/Glucose trending up over last 3 visits/)).toBeInTheDocument();
+  });
+
+  it('renders patient questions from threads', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText('What does high glucose mean for me?')).toBeInTheDocument();
+    expect(screen.getByText('Should I change my diet?')).toBeInTheDocument();
+  });
+
+  it('renders normal findings grid', () => {
+    render(<DoctorSummaryDocument {...baseProps} />);
+    expect(screen.getByText(/Sodium/)).toBeInTheDocument();
+  });
+
+  it('renders without crashing when no interpretation or threads given', () => {
+    render(
+      <DoctorSummaryDocument
+        reportTitle="Minimal"
+        reportDate="2026-01-01"
+        patientName="John"
+        flaggedFindings={[]}
+        allFindings={[]}
+        threads={[]}
+      />
+    );
+    expect(screen.getByText('Minimal')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/reports/__tests__/ThreadsFlow.test.tsx
+++ b/frontend/src/app/reports/__tests__/ThreadsFlow.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { PatientQuestions } from '../../../../components/PatientQuestions';
+import { ThreadView } from '../../../../components/ThreadView';
+
+process.env.NEXT_PUBLIC_BACKEND_URL = 'http://test';
+
+describe('Threads and Questions Flow', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn() as any;
+    vi.clearAllMocks();
+  });
+
+  it('PatientQuestions fetches prompts and displays them', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ prompts: ['Question 1', 'Question 2'] }),
+    });
+
+    render(<PatientQuestions reportId="123" accessToken="token" onThreadCreated={vi.fn()} />);
+
+    expect(screen.getByText(/Generating personalized questions/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Question 1')).toBeInTheDocument();
+      expect(screen.getByText('Question 2')).toBeInTheDocument();
+    });
+  });
+
+  it('ThreadView fetches threads and renders them', async () => {
+    const mockThread = {
+      id: 'thread-1',
+      title: 'My Thread',
+      messages: [
+        {
+          id: 'msg-1',
+          author_name: 'Patient User',
+          kind: 'text',
+          body: 'What is this?',
+          created_at: new Date().toISOString(),
+        },
+        {
+          id: 'msg-2',
+          author_name: 'Dr. Clinician',
+          kind: 'template',
+          body: JSON.stringify({ meaning: 'It means nothing.', urgency: 'routine', action: 'Rest.' }),
+          created_at: new Date().toISOString(),
+        }
+      ]
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([mockThread]),
+    });
+
+    render(<ThreadView reportId="123" accessToken="token" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Thread')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Patient User')).toBeInTheDocument();
+    expect(screen.getByText('What is this?')).toBeInTheDocument();
+
+    expect(screen.getByText('Clinician Response')).toBeInTheDocument();
+    expect(screen.getByText('It means nothing.')).toBeInTheDocument();
+    expect(screen.getByText('routine')).toBeInTheDocument();
+    expect(screen.getByText('Rest.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DoctorSummaryDocument.tsx
+++ b/frontend/src/components/DoctorSummaryDocument.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+/**
+ * DoctorSummaryDocument — FR13
+ *
+ * This component renders a print-optimised, one-page doctor-ready summary.
+ * It is hidden from normal screen rendering (display:none) and only becomes
+ * visible when window.print() is called via @media print rules.
+ *
+ * The PDF is generated entirely client-side. Nothing is sent to or stored on
+ * the server (FR13 requirement).
+ */
+
+import React from 'react';
+
+export interface SummaryFinding {
+  test_name: string;
+  value: string;
+  unit?: string;
+  flag: string;
+  reference_range?: string;
+}
+
+export interface SummaryThread {
+  title: string | null;
+  patientQuestions: string[];
+}
+
+export interface DoctorSummaryDocumentProps {
+  reportTitle: string;
+  reportDate: string;
+  patientName: string;
+  flaggedFindings: SummaryFinding[];
+  allFindings: SummaryFinding[];
+  interpretationSummary?: string;
+  trendNotes?: string;
+  threads: SummaryThread[];
+}
+
+function flagColor(flag: string): string {
+  switch (flag.toLowerCase()) {
+    case 'high':
+      return '#dc2626';
+    case 'low':
+      return '#2563eb';
+    case 'abnormal':
+      return '#d97706';
+    default:
+      return '#16a34a';
+  }
+}
+
+function flagBg(flag: string): string {
+  switch (flag.toLowerCase()) {
+    case 'high':
+      return '#fef2f2';
+    case 'low':
+      return '#eff6ff';
+    case 'abnormal':
+      return '#fffbeb';
+    default:
+      return '#f0fdf4';
+  }
+}
+
+export function DoctorSummaryDocument({
+  reportTitle,
+  reportDate,
+  patientName,
+  flaggedFindings,
+  allFindings,
+  interpretationSummary,
+  trendNotes,
+  threads,
+}: DoctorSummaryDocumentProps) {
+  const patientQuestions = threads.flatMap((t) => t.patientQuestions);
+
+  return (
+    <div className="doctor-summary-print" id="doctor-summary-print-root">
+      {/* ── Header ── */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', paddingBottom: '1rem', borderBottom: '3px solid #1d4ed8' }}>
+        <div>
+          <div style={{ fontSize: '0.7rem', letterSpacing: '0.1em', textTransform: 'uppercase', color: '#6b7280', marginBottom: '0.25rem' }}>
+            ReportX · Doctor-Ready Summary
+          </div>
+          <h1 style={{ margin: 0, fontSize: '1.4rem', color: '#1e3a5f', fontWeight: 700 }}>
+            {reportTitle || 'Lab Results Summary'}
+          </h1>
+          <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: '#374151' }}>
+            Patient: <strong>{patientName}</strong> &nbsp;·&nbsp; Report Date: <strong>{reportDate}</strong>
+          </div>
+        </div>
+        <div style={{ textAlign: 'right', fontSize: '0.75rem', color: '#9ca3af' }}>
+          <div>Printed: {new Date().toLocaleDateString()}</div>
+          <div style={{ marginTop: '0.2rem', fontStyle: 'italic' }}>Confidential — for treating clinician only</div>
+        </div>
+      </div>
+
+      {/* ── Flagged Values ── */}
+      {flaggedFindings.length > 0 && (
+        <section style={{ marginBottom: '1.25rem' }}>
+          <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#374151', margin: '0 0 0.6rem 0', fontWeight: 700 }}>
+            ⚠ Flagged Values
+          </h2>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+            <thead>
+              <tr style={{ backgroundColor: '#f1f5f9' }}>
+                <th style={{ textAlign: 'left', padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0' }}>Test</th>
+                <th style={{ textAlign: 'center', padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0' }}>Result</th>
+                <th style={{ textAlign: 'center', padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0' }}>Flag</th>
+                <th style={{ textAlign: 'center', padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0' }}>Reference Range</th>
+              </tr>
+            </thead>
+            <tbody>
+              {flaggedFindings.map((f, i) => (
+                <tr key={i} style={{ backgroundColor: flagBg(f.flag) }}>
+                  <td style={{ padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0', fontWeight: 600 }}>{f.test_name}</td>
+                  <td style={{ padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0', textAlign: 'center' }}>
+                    {f.value} {f.unit || ''}
+                  </td>
+                  <td style={{ padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0', textAlign: 'center' }}>
+                    <span style={{ color: flagColor(f.flag), fontWeight: 700, textTransform: 'uppercase', fontSize: '0.75rem' }}>{f.flag}</span>
+                  </td>
+                  <td style={{ padding: '0.35rem 0.5rem', border: '1px solid #e2e8f0', textAlign: 'center', color: '#6b7280' }}>
+                    {f.reference_range || '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {/* ── All Findings (compact) ── */}
+      {allFindings.filter(f => !['high','low','abnormal'].includes(f.flag.toLowerCase())).length > 0 && (
+        <section style={{ marginBottom: '1.25rem' }}>
+          <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#374151', margin: '0 0 0.6rem 0', fontWeight: 700 }}>
+            ✓ Normal Results
+          </h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '0.3rem', fontSize: '0.78rem' }}>
+            {allFindings
+              .filter(f => !['high','low','abnormal'].includes(f.flag.toLowerCase()))
+              .map((f, i) => (
+                <div key={i} style={{ background: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: '4px', padding: '0.3rem 0.5rem' }}>
+                  <span style={{ fontWeight: 600 }}>{f.test_name}:</span>{' '}
+                  {f.value} {f.unit || ''} <span style={{ color: '#16a34a', fontSize: '0.7rem' }}>✓</span>
+                </div>
+              ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── AI Explanation ── */}
+      {interpretationSummary && (
+        <section style={{ marginBottom: '1.25rem', background: '#eff6ff', border: '1px solid #bfdbfe', borderRadius: '6px', padding: '0.75rem 1rem' }}>
+          <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#1d4ed8', margin: '0 0 0.4rem 0', fontWeight: 700 }}>
+            🤖 AI Explanation Summary
+          </h2>
+          <p style={{ margin: 0, fontSize: '0.83rem', color: '#1e3a5f', lineHeight: 1.6 }}>{interpretationSummary}</p>
+          <p style={{ margin: '0.5rem 0 0', fontSize: '0.68rem', color: '#6b7280', fontStyle: 'italic' }}>
+            AI-generated summary. Please review against patient's full clinical history.
+          </p>
+        </section>
+      )}
+
+      {/* ── Trend Notes ── */}
+      {trendNotes && (
+        <section style={{ marginBottom: '1.25rem', background: '#fefce8', border: '1px solid #fde047', borderRadius: '6px', padding: '0.75rem 1rem' }}>
+          <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#a16207', margin: '0 0 0.4rem 0', fontWeight: 700 }}>
+            📈 Trend Notes
+          </h2>
+          <p style={{ margin: 0, fontSize: '0.83rem', color: '#713f12', lineHeight: 1.6 }}>{trendNotes}</p>
+        </section>
+      )}
+
+      {/* ── Patient Questions ── */}
+      {patientQuestions.length > 0 && (
+        <section style={{ marginBottom: '1.25rem', background: '#fdf4ff', border: '1px solid #e9d5ff', borderRadius: '6px', padding: '0.75rem 1rem' }}>
+          <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#7e22ce', margin: '0 0 0.4rem 0', fontWeight: 700 }}>
+            💬 Patient's Questions for Clinician
+          </h2>
+          <ol style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.83rem', color: '#374151', lineHeight: 1.7 }}>
+            {patientQuestions.map((q, i) => (
+              <li key={i}>{q}</li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {/* ── Footer ── */}
+      <div style={{ marginTop: '1.5rem', paddingTop: '0.75rem', borderTop: '1px solid #e2e8f0', display: 'flex', justifyContent: 'space-between', fontSize: '0.68rem', color: '#9ca3af' }}>
+        <span>Generated by ReportX — AI-assisted health report platform</span>
+        <span>Clinician review required before any clinical decisions are made.</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DoctorSummaryDocument.tsx
+++ b/frontend/src/components/DoctorSummaryDocument.tsx
@@ -158,7 +158,7 @@ export function DoctorSummaryDocument({
           </h2>
           <p style={{ margin: 0, fontSize: '0.83rem', color: '#1e3a5f', lineHeight: 1.6 }}>{interpretationSummary}</p>
           <p style={{ margin: '0.5rem 0 0', fontSize: '0.68rem', color: '#6b7280', fontStyle: 'italic' }}>
-            AI-generated summary. Please review against patient's full clinical history.
+            AI-generated summary. Please review against patient&apos;s full clinical history.
           </p>
         </section>
       )}
@@ -177,7 +177,7 @@ export function DoctorSummaryDocument({
       {patientQuestions.length > 0 && (
         <section style={{ marginBottom: '1.25rem', background: '#fdf4ff', border: '1px solid #e9d5ff', borderRadius: '6px', padding: '0.75rem 1rem' }}>
           <h2 style={{ fontSize: '0.9rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: '#7e22ce', margin: '0 0 0.4rem 0', fontWeight: 700 }}>
-            💬 Patient's Questions for Clinician
+            💬 Patient&apos;s Questions for Clinician
           </h2>
           <ol style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.83rem', color: '#374151', lineHeight: 1.7 }}>
             {patientQuestions.map((q, i) => (

--- a/frontend/src/components/PatientQuestions.tsx
+++ b/frontend/src/components/PatientQuestions.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect } from 'react';
+
+interface PatientQuestionsProps {
+  reportId: string;
+  accessToken: string;
+  onThreadCreated: (threadId: string) => void;
+}
+
+export function PatientQuestions({ reportId, accessToken, onThreadCreated }: PatientQuestionsProps) {
+  const [prompts, setPrompts] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [selectedPromptIndex, setSelectedPromptIndex] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [freeText, setFreeText] = useState(false);
+
+  const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    async function fetchPrompts() {
+      setLoading(true);
+      setError('');
+      try {
+        const response = await fetch(`${backend}/api/v1/reports/${reportId}/question-prompts`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        if (!response.ok) {
+          throw new Error('Failed to load suggested questions');
+        }
+        const data = await response.json();
+        setPrompts(data.prompts || []);
+      } catch (err: any) {
+        setError(err.message || 'An error occurred loading questions.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchPrompts();
+  }, [reportId, accessToken, backend]);
+
+  const handleSelectPrompt = (index: number) => {
+    setSelectedPromptIndex(index);
+    setEditValue(prompts[index]);
+    setFreeText(false);
+  };
+
+  const handleFreeText = () => {
+    setSelectedPromptIndex(-1);
+    setEditValue('');
+    setFreeText(true);
+  };
+
+  const handleSend = async () => {
+    if (!editValue.trim()) return;
+    setSubmitting(true);
+    setError('');
+    
+    try {
+      const response = await fetch(`${backend}/api/v1/reports/${reportId}/threads`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          initial_message: editValue,
+          title: 'Questions for Clinician',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to send question');
+      }
+
+      const thread = await response.json();
+      onThreadCreated(thread.id);
+      
+      setSelectedPromptIndex(null);
+      setEditValue('');
+      setFreeText(false);
+    } catch (err: any) {
+      setError(err.message || 'Failed to submit question.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="card">Generating personalized questions...</div>;
+  }
+
+  return (
+    <div className="card">
+      <h2>Questions for My Clinician</h2>
+      <p>Select a suggested question to ask your healthcare provider, or write your own.</p>
+      
+      {error && <div className="alert alert-error">{error}</div>}
+      
+      <div className="flex flex-col gap-2 my-4" style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '1rem' }}>
+        {prompts.map((prompt, index) => (
+          <button 
+            key={index} 
+            className="nav-btn" 
+            style={{ textAlign: 'left', background: selectedPromptIndex === index ? '#f0f0f0' : 'white', cursor: 'pointer', padding: '0.75rem', border: '1px solid #ccc', borderRadius: '4px' }}
+            onClick={() => handleSelectPrompt(index)}
+          >
+            {prompt}
+          </button>
+        ))}
+        <button 
+            className="nav-btn" 
+            style={{ textAlign: 'left', background: freeText ? '#f0f0f0' : 'white', cursor: 'pointer', padding: '0.75rem', border: '1px dashed #ccc', borderRadius: '4px' }}
+            onClick={handleFreeText}
+          >
+            + Ask something else (Free text)
+          </button>
+      </div>
+
+      {(selectedPromptIndex !== null || freeText) && (
+        <div style={{ marginTop: '1rem', borderTop: '1px solid #eee', paddingTop: '1rem' }}>
+          <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
+            Edit your message:
+          </label>
+          <textarea 
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            rows={3}
+            style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc', marginBottom: '0.5rem' }}
+            disabled={submitting}
+          />
+          <button className="nav-btn nav-btn-primary" onClick={handleSend} disabled={submitting || !editValue.trim()}>
+            {submitting ? 'Sending...' : 'Send to Clinician'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -21,9 +21,10 @@ export interface ConversationThread {
 interface ThreadViewProps {
   reportId: string;
   accessToken: string;
+  onThreadsLoaded?: (threads: ConversationThread[]) => void;
 }
 
-export function ThreadView({ reportId, accessToken }: ThreadViewProps) {
+export function ThreadView({ reportId, accessToken, onThreadsLoaded }: ThreadViewProps) {
   const { user } = useAuth();
   const [threads, setThreads] = useState<ConversationThread[]>([]);
   const [loading, setLoading] = useState(false);
@@ -43,8 +44,9 @@ export function ThreadView({ reportId, accessToken }: ThreadViewProps) {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (response.ok) {
-        const data = await response.json();
+        const data: ConversationThread[] = await response.json();
         setThreads(data || []);
+        onThreadsLoaded?.(data || []);
       }
     } catch (err) {
       console.error('Failed to fetch threads', err);

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/store/authStore';
 
 export interface ThreadMessage {
@@ -59,7 +59,7 @@ export function ThreadView({ reportId, accessToken, onThreadsLoaded }: ThreadVie
     fetchThreads();
     const intv = setInterval(fetchThreads, 10000);
     return () => clearInterval(intv);
-  }, [reportId, accessToken, backend]);
+  }, [fetchThreads]);
 
   const handleSendReply = async (threadId: string) => {
     if (!replyText.trim()) return;

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '@/store/authStore';
+
+export interface ThreadMessage {
+  id: string;
+  author_user_id: string;
+  author_name: string;
+  kind: 'text' | 'template' | 'system';
+  body: string;
+  created_at: string;
+}
+
+export interface ConversationThread {
+  id: string;
+  report_id: string;
+  title: string | null;
+  status: string;
+  messages: ThreadMessage[];
+}
+
+interface ThreadViewProps {
+  reportId: string;
+  accessToken: string;
+}
+
+export function ThreadView({ reportId, accessToken }: ThreadViewProps) {
+  const { user } = useAuth();
+  const [threads, setThreads] = useState<ConversationThread[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [replyText, setReplyText] = useState('');
+  
+  const [isClinicianMock, setIsClinicianMock] = useState(false);
+  const [clinicianMeaning, setClinicianMeaning] = useState('');
+  const [clinicianUrgency, setClinicianUrgency] = useState('routine');
+  const [clinicianAction, setClinicianAction] = useState('');
+
+  const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+
+  const fetchThreads = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`${backend}/api/v1/reports/${reportId}/threads`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setThreads(data || []);
+      }
+    } catch (err) {
+      console.error('Failed to fetch threads', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchThreads();
+    const intv = setInterval(fetchThreads, 10000);
+    return () => clearInterval(intv);
+  }, [reportId, accessToken, backend]);
+
+  const handleSendReply = async (threadId: string) => {
+    if (!replyText.trim()) return;
+    try {
+      await fetch(`${backend}/api/v1/threads/${threadId}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ body: replyText }),
+      });
+      setReplyText('');
+      fetchThreads();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSendClinicianTemplate = async (threadId: string) => {
+    if (!clinicianMeaning.trim() || !clinicianAction.trim()) return;
+    try {
+      await fetch(`${backend}/api/v1/threads/${threadId}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          template_payload: {
+            meaning: clinicianMeaning,
+            urgency: clinicianUrgency,
+            action: clinicianAction,
+          }
+        }),
+      });
+      setClinicianMeaning('');
+      setClinicianUrgency('routine');
+      setClinicianAction('');
+      setIsClinicianMock(false);
+      fetchThreads();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading && threads.length === 0) return <div>Loading threads...</div>;
+  if (threads.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: '2rem' }}>
+      <h2>Conversations</h2>
+      <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
+        {threads.map((thread) => (
+          <div key={thread.id} className="card" style={{ padding: '1rem', border: '1px solid #ccc' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h3 style={{ margin: 0 }}>{thread.title || 'Thread'}</h3>
+                <div>
+                   <label style={{ fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', background: '#ebf8ff', padding: '0.3rem', borderRadius: '4px' }}>
+                    <input type="checkbox" checked={isClinicianMock} onChange={e => setIsClinicianMock(e.target.checked)} />
+                    Simulate Clinician Access
+                   </label>
+                </div>
+            </div>
+            
+            <div style={{ marginTop: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              {thread.messages.map((msg) => {
+                const isMe = msg.author_user_id === user?.id;
+                
+                if (msg.kind === 'template') {
+                  let payload: any = {};
+                  try { payload = JSON.parse(msg.body); } catch(e){}
+                  
+                  return (
+                    <div key={msg.id} style={{ alignSelf: 'flex-start', background: '#f0fdf4', padding: '1rem', borderRadius: '8px', borderLeft: '4px solid #16a34a', maxWidth: '80%' }}>
+                      <div style={{ fontWeight: 'bold', fontSize: '0.9rem', marginBottom: '0.5rem', color: '#16a34a' }}>
+                        Clinician Response
+                      </div>
+                      <div style={{ marginBottom: '0.5rem' }}>
+                        <strong>What it means:</strong> {payload.meaning}
+                      </div>
+                      <div style={{ marginBottom: '0.5rem' }}>
+                        <strong>Urgency:</strong> <span style={{ textTransform: 'capitalize', padding: '0.1rem 0.4rem', background: payload.urgency === 'urgent' ? '#fee2e2' : payload.urgency === 'soon' ? '#fef3c7' : '#e0e7ff', borderRadius: '4px' }}>{payload.urgency}</span>
+                      </div>
+                      <div>
+                        <strong>Next step:</strong> {payload.action}
+                      </div>
+                      <small style={{ color: '#666', display: 'block', marginTop: '0.5rem' }}>{new Date(msg.created_at).toLocaleString()}</small>
+                    </div>
+                  );
+                }
+
+                return (
+                  <div key={msg.id} style={{ alignSelf: isMe ? 'flex-end' : 'flex-start', background: isMe ? '#dbeafe' : '#f3f4f6', padding: '0.75rem', borderRadius: '8px', maxWidth: '70%' }}>
+                    <div style={{ fontWeight: 'bold', fontSize: '0.8rem', marginBottom: '0.2rem' }}>{msg.author_name}</div>
+                    <div>{msg.body}</div>
+                    <div style={{ fontSize: '0.7rem', color: '#666', marginTop: '0.2rem', textAlign: 'right' }}>
+                      {new Date(msg.created_at).toLocaleString()}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div style={{ marginTop: '1rem', borderTop: '1px solid #eee', paddingTop: '1rem' }}>
+                {isClinicianMock ? (
+                  <div style={{ background: '#f8fafc', padding: '1rem', borderRadius: '8px', border: '1px solid #e2e8f0' }}>
+                    <h4 style={{ margin: '0 0 1rem 0' }}>Clinician Response Template</h4>
+                    <div className="field" style={{ marginBottom: '0.5rem' }}>
+                      <label>What the result means:</label>
+                      <textarea value={clinicianMeaning} onChange={e => setClinicianMeaning(e.target.value)} rows={2} style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }} />
+                    </div>
+                    <div className="field" style={{ marginBottom: '0.5rem' }}>
+                      <label>Urgency:</label>
+                      <select value={clinicianUrgency} onChange={e => setClinicianUrgency(e.target.value)} style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+                        <option value="routine">Routine</option>
+                        <option value="soon">Soon</option>
+                        <option value="urgent">Urgent</option>
+                      </select>
+                    </div>
+                    <div className="field" style={{ marginBottom: '1rem' }}>
+                      <label>Recommended action:</label>
+                      <textarea value={clinicianAction} onChange={e => setClinicianAction(e.target.value)} rows={2} style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }} />
+                    </div>
+                    <button className="nav-btn nav-btn-primary" onClick={() => handleSendClinicianTemplate(thread.id)}>Submit Clinical Response</button>
+                  </div>
+                ) : (
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <input 
+                      style={{ flex: 1, padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }} 
+                      type="text" 
+                      placeholder="Type a reply..." 
+                      value={replyText} 
+                      onChange={e => setReplyText(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') handleSendReply(thread.id); }}
+                    />
+                    <button className="nav-btn nav-btn-primary" onClick={() => handleSendReply(thread.id)}>Reply</button>
+                  </div>
+                )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
 In ere, I tried to built and wired up two major patient-facing features in the ReportX application, committing all changes to the Question-for-Clinician branch.

1. FR11: "Questions for My Clinician" Workflow
We implemented the end-to-end flow allowing patients to generate questions and clinicians to respond.

Backend: Created the ConversationThread and ThreadMessage data models and API endpoints. We also integrated the LLM to automatically generate context-aware questions from flagged lab results with deterministic fallbacks.
Frontend: Developed PatientQuestions.tsx for displaying prompts and accepting patient questions, and ThreadView.tsx for rendering the conversation thread, including structured clinical responses (meaning, urgency, action).
Integration: Embedded these components into the main report view.
2. FR13: Doctor-Ready Summary Export
We implemented a client-side-only PDF export that produces a single-page medical summary.

Component: Built DoctorSummaryDocument.tsx, a nicely formatted, print-only component that gathers:
Patient metadata and report dates.
A color-coded table (red/amber/blue) of flagged values.
A compact layout for normal values.
The AI interpretation summary.
The patient's questions extracted directly from the FR11 conversation threads.
UI Integration: Added a "📄 Export Doctor Summary" button to the report header and wired it up via browser window.print().
Share Workflow: Added a checkbox in the Sharing Preferences ("Also download Doctor-Ready Summary PDF") that automatically triggers a PDF download right after generating a share link.
CSS & Tests: Created strict @media print rules to ensure only the document prints (hiding all sidebars/navbars) and added 7 Vitest automated tests covering all summary sections.