### PR TITLE
Consent-Driven Sharing, Expiry, Revocation, and Audit-Log Backend 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ __pycache__/
 *.egg-info/
 **/*.egg-info/
 
+# Git worktrees
+.worktrees/
+
 # Others
 coverage/
 .idea/

--- a/backend/app/dependencies/reports.py
+++ b/backend/app/dependencies/reports.py
@@ -7,7 +7,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.db.models import ConsentScope, ConsentShare, Report
+from app.db.models import AuditEvent, ConsentScope, ConsentShare, Report
 from app.db.session import get_db_session
 
 from .auth import AuthContext, get_current_auth_context
@@ -30,8 +30,10 @@ async def get_accessible_report(
         return report
 
     now = datetime.now(UTC)
-    share_id = await session.scalar(
-        select(ConsentShare.id)
+    
+    # Check for active, non-revoked, non-expired shares
+    share = await session.scalar(
+        select(ConsentShare)
         .where(
             ConsentShare.subject_user_id == report.subject_user_id,
             ConsentShare.grantee_user_id == auth.user.id,
@@ -50,7 +52,102 @@ async def get_accessible_report(
         )
         .limit(1)
     )
-    if share_id is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-
-    return report
+    
+    if share is not None:
+        audit = AuditEvent(
+            actor_user_id=auth.user.id,
+            subject_user_id=auth.user.id,
+            resource_type="consent_share",
+            resource_id=share.id,
+            action="view",
+            context={
+                "report_id": report.id,
+                "scope": share.scope.value,
+                "access_level": share.access_level.value,
+            },
+            occurred_at=now,
+        )
+        session.add(audit)
+        await session.commit()
+        return report
+    
+    # Check for revoked shares
+    revoked_share = await session.scalar(
+        select(ConsentShare)
+        .where(
+            ConsentShare.subject_user_id == report.subject_user_id,
+            ConsentShare.grantee_user_id == auth.user.id,
+            ConsentShare.revoked_at.is_not(None),
+            or_(
+                and_(
+                    ConsentShare.scope == ConsentScope.PATIENT,
+                    ConsentShare.report_id.is_(None),
+                ),
+                and_(
+                    ConsentShare.scope == ConsentScope.REPORT,
+                    ConsentShare.report_id == report.id,
+                ),
+            ),
+        )
+        .limit(1)
+    )
+    if revoked_share is not None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access has been revoked")
+    
+    # Check for expired shares
+    expired_share = await session.scalar(
+        select(ConsentShare)
+        .where(
+            ConsentShare.subject_user_id == report.subject_user_id,
+            ConsentShare.grantee_user_id == auth.user.id,
+            ConsentShare.revoked_at.is_(None),
+            ConsentShare.expires_at <= now,
+            or_(
+                and_(
+                    ConsentShare.scope == ConsentScope.PATIENT,
+                    ConsentShare.report_id.is_(None),
+                ),
+                and_(
+                    ConsentShare.scope == ConsentScope.REPORT,
+                    ConsentShare.report_id == report.id,
+                ),
+            ),
+        )
+        .limit(1)
+    )
+    
+    if expired_share is not None:
+        # Create SHARE_EXPIRED audit event (first time expired share is accessed)
+        # Check if we already logged this expiry
+        existing_expiry_event = await session.scalar(
+            select(AuditEvent).where(
+                AuditEvent.resource_type == "consent_share",
+                AuditEvent.action == "expired",
+                AuditEvent.resource_id == expired_share.id,
+            )
+        )
+        
+        if existing_expiry_event is None:
+            # Create audit event for expiry
+            audit = AuditEvent(
+                actor_user_id=None,  # System action
+                subject_user_id=auth.user.id,
+                resource_type="consent_share",
+                resource_id=expired_share.id,
+                action="expired",
+                context={
+                    "report_id": report.id if expired_share.scope == ConsentScope.REPORT else None,
+                    "scope": expired_share.scope.value,
+                    "access_level": expired_share.access_level.value,
+                    "expired_at": now.isoformat(),
+                    "expires_at": expired_share.expires_at.isoformat(),
+                },
+                occurred_at=now,
+            )
+            session.add(audit)
+            await session.commit()
+        
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Share has expired")
+    
+    # No valid share found
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,11 @@ async def app_lifespan(app: FastAPI):
             if count > 0:
                 logging.info(f"Cleaned up {count} expired shares")
     
-    # Schedule cleanup every hour (configurable via env)
+    # CLEANUP_INTERVAL_MINUTES controls how often expired shared reports are deleted.
+    # Default: 5 minutes.
+    # Valid values: positive whole-number minutes; lower values increase scheduler and
+    # database activity, while higher values leave expired shares in place longer.
+    # For production, choose an interval that balances prompt cleanup with operational load.
     cleanup_interval = int(os.getenv('CLEANUP_INTERVAL_MINUTES', '5'))
     scheduler.add_job(
         scheduled_cleanup,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
 import os
+import sys
 import time
 import uuid
 from contextlib import asynccontextmanager
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -12,17 +14,23 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response
 
 from .db.session import build_database_manager
+from .routers.audit import router as audit_router
 from .routers.auth import router as auth_router
 from .routers.health import router as health_router
 from .routers.interpret import router as interpret_router
 from .routers.parse import router as parse_router
 from .routers.reports import router as reports_router
 from .routers.translate import router as translate_router
+from .services.reports import cleanup_expired_shares
 
 
 async def _run_alembic_migrations(project_root: str, timeout: int) -> None:
     process = await asyncio.create_subprocess_exec(
-        'alembic', 'upgrade', 'head',
+        sys.executable,
+        '-m',
+        'alembic',
+        'upgrade',
+        'head',
         cwd=project_root,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -53,9 +61,32 @@ async def app_lifespan(app: FastAPI):
         logging.exception('Failed to apply migrations on startup')
         raise
 
+    # Start background scheduler for cleanup jobs
+    scheduler = AsyncIOScheduler()
+    
+    async def scheduled_cleanup():
+        """Wrapper to execute cleanup with a database session."""
+        async with app.state.database.session_factory() as session:
+            count = await cleanup_expired_shares(session)
+            if count > 0:
+                logging.info(f"Cleaned up {count} expired shares")
+    
+    # Schedule cleanup every hour (configurable via env)
+    cleanup_interval = int(os.getenv('CLEANUP_INTERVAL_MINUTES', '5'))
+    scheduler.add_job(
+        scheduled_cleanup,
+        'interval',
+        minutes=cleanup_interval,
+        id='cleanup-expired-shares',
+        name='Cleanup expired shares',
+    )
+    scheduler.start()
+    app.state.scheduler = scheduler
+
     try:
         yield
     finally:
+        scheduler.shutdown()
         await app.state.database.dispose()
 
 
@@ -177,6 +208,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router, prefix="/api/v1")
     app.include_router(parse_router, prefix="/api/v1")
     app.include_router(interpret_router, prefix="/api/v1")
+    app.include_router(audit_router, prefix="/api/v1")
     app.include_router(reports_router, prefix="/api/v1")
     app.include_router(translate_router, prefix="/api/v1")
 

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -1,0 +1,58 @@
+"""Audit log endpoints"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db_session
+from app.dependencies.auth import AuthContext, get_current_auth_context
+from app.services.reports import AuditLogEntry, get_report_audit_log, ReportServiceError
+
+router = APIRouter(prefix="/audit", tags=["audit"])
+
+
+class AuditEventOut(BaseModel):
+    """Audit event output"""
+    event_id: str
+    action: str
+    occurred_at: datetime
+    context: dict
+
+
+@router.get("/reports/{report_id}", response_model=list[AuditEventOut])
+async def get_report_audit_log_endpoint(
+    report_id: str,
+    action: str | None = None,
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[AuditEventOut]:
+    """Get audit log for a report owned by authenticated user.
+    
+    Filters:
+        action: Comma-separated list of actions (created, revoked, expired)
+    """
+    try:
+        actions = None
+        if action:
+            actions = [a.strip() for a in action.split(",") if a.strip()]
+        
+        entries = await get_report_audit_log(
+            session,
+            report_id=report_id,
+            owner_user_id=auth.user.id,
+            actions=actions,
+        )
+    except ReportServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+    
+    return [
+        AuditEventOut(
+            event_id=entry.event_id,
+            action=entry.action,
+            occurred_at=entry.occurred_at,
+            context=entry.context,
+        )
+        for entry in entries
+    ]

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -19,7 +19,9 @@ from app.dependencies.reports import get_accessible_report
 from app.services.reports import (
     ReportFindingCreateInput,
     ReportServiceError,
+    ClinicianSharedReportItem,
     create_report_for_user,
+    get_clinician_shared_reports,
     list_reports_for_user,
     revoke_report_share,
     share_report_with_user,
@@ -217,6 +219,63 @@ def _report_out(report: Report) -> ReportOut:
         observed_at=report.observed_at,
         findings=[_finding_out(finding) for finding in findings],
     )
+
+
+class UserOut(BaseModel):
+    """User profile output"""
+    id: str
+    email: str
+    display_name: str
+    preferred_language: str | None = None
+
+
+class ClinicianSharedReportOut(BaseModel):
+    """Clinician's view of a shared report"""
+    share_id: str
+    report_id: str
+    report: ReportOut
+    patient: UserOut
+    scope: str
+    access_level: str
+    shared_at: datetime
+    expires_at: datetime
+
+
+@router.get("/shared-reports", response_model=list[ClinicianSharedReportOut])
+async def list_clinician_shared_reports(
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[ClinicianSharedReportOut]:
+    """List all reports actively shared with the authenticated clinician."""
+    if "clinician" not in auth.roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only clinicians may view shared reports",
+        )
+
+    items = await get_clinician_shared_reports(
+        session,
+        clinician_user_id=auth.user.id,
+    )
+    
+    return [
+        ClinicianSharedReportOut(
+            share_id=item.share_id,
+            report_id=item.report_id,
+            report=_report_out(item.report),
+            patient=UserOut(
+                id=item.patient.id,
+                email=item.patient.email,
+                display_name=item.patient.display_name,
+                preferred_language=item.patient.preferred_language,
+            ),
+            scope=item.scope,
+            access_level=item.access_level,
+            shared_at=item.shared_at,
+            expires_at=item.expires_at,
+        )
+        for item in items
+    ]
 
 
 @router.get("/{report_id}", response_model=ReportDetailResponse)

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db.models import (
+    AuditEvent,
     ConsentAccessLevel,
     ConsentScope,
     ConsentShare,
@@ -24,6 +25,30 @@ class ReportServiceError(Exception):
         super().__init__(detail)
         self.detail = detail
         self.status_code = status_code
+
+
+async def _create_audit_event(
+    session: AsyncSession,
+    *,
+    actor_user_id: str | None,
+    subject_user_id: str | None,
+    resource_type: str,
+    resource_id: str,
+    action: str,
+    context: dict | None = None,
+) -> AuditEvent:
+    """Create an audit event record synchronously within transaction."""
+    audit = AuditEvent(
+        actor_user_id=actor_user_id,
+        subject_user_id=subject_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        context=context or {},
+        occurred_at=datetime.now(UTC),
+    )
+    session.add(audit)
+    return audit
 
 
 @dataclass(frozen=True)
@@ -146,7 +171,11 @@ def _require_report_owner(*, report: Report, owner_user_id: str, action: str) ->
 
 
 async def _load_grantee(session: AsyncSession, *, clinician_email: str) -> User:
-    grantee = await session.scalar(select(User).where(User.email == clinician_email))
+    grantee = await session.scalar(
+        select(User)
+        .where(User.email == clinician_email)
+        .options(selectinload(User.roles))  # Eagerly load roles to avoid lazy-load in async context
+    )
     if grantee is None:
         raise ReportServiceError("Clinician user not found", 404)
     return grantee
@@ -170,6 +199,11 @@ async def share_report_with_user(
     grantee = await _load_grantee(session, clinician_email=clinician_email)
     if grantee.id == owner_user_id:
         raise ReportServiceError("Cannot share with yourself", 400)
+    
+    # Verify recipient is a clinician
+    clinician_roles = {role.name for role in grantee.roles}
+    if "clinician" not in clinician_roles:
+        raise ReportServiceError("Recipient must have clinician role", 400)
 
     target_report_id = report.id if scope == ConsentScope.REPORT else None
     existing_share = await session.scalar(
@@ -199,6 +233,24 @@ async def share_report_with_user(
         share = existing_share
 
     await session.flush()
+    
+    # Create audit event for share creation
+    await _create_audit_event(
+        session,
+        actor_user_id=owner_user_id,
+        subject_user_id=grantee.id,
+        resource_type="consent_share",
+        resource_id=share.id,
+        action="created",
+        context={
+            "report_id": report.id if scope == ConsentScope.REPORT else None,
+            "scope": scope.value,
+            "access_level": access_level.value,
+            "expires_at": expires_at.isoformat(),
+            "grantee_email": grantee.email,
+        },
+    )
+    
     await sync_subject_report_sharing_modes(session, subject_user_id=report.subject_user_id)
     await session.commit()
     await session.refresh(share)
@@ -241,5 +293,237 @@ async def revoke_report_share(
 
     share.revoked_at = datetime.now(UTC)
     await session.flush()
+    
+    # Create audit event for share revocation
+    await _create_audit_event(
+        session,
+        actor_user_id=owner_user_id,
+        subject_user_id=grantee.id,
+        resource_type="consent_share",
+        resource_id=share.id,
+        action="revoked",
+        context={
+            "report_id": report.id if share.scope == ConsentScope.REPORT else None,
+            "scope": share.scope.value,
+            "access_level": share.access_level.value,
+            "grantee_email": grantee.email,
+        },
+    )
+    
     await sync_subject_report_sharing_modes(session, subject_user_id=report.subject_user_id)
     await session.commit()
+
+
+@dataclass(frozen=True)
+class ClinicianSharedReportItem:
+    """Clinician's view of a shared report with patient profile"""
+    share_id: str
+    report_id: str
+    report: Report
+    patient: User
+    scope: str
+    access_level: str
+    shared_at: datetime
+    expires_at: datetime
+
+
+async def get_clinician_shared_reports(
+    session: AsyncSession,
+    *,
+    clinician_user_id: str,
+) -> list[ClinicianSharedReportItem]:
+    """Get all reports actively shared with a clinician."""
+    now = datetime.now(UTC)
+
+    share_rows = await session.execute(
+        select(ConsentShare, User)
+        .join(User, ConsentShare.subject_user_id == User.id)
+        .where(
+            ConsentShare.grantee_user_id == clinician_user_id,
+            ConsentShare.revoked_at.is_(None),
+            ConsentShare.expires_at > now,
+        )
+        .order_by(ConsentShare.created_at.desc())
+    )
+
+    by_report: dict[str, ClinicianSharedReportItem] = {}
+
+    for share, patient in share_rows.unique():
+        if share.scope == ConsentScope.REPORT and share.report_id is not None:
+            report = await session.scalar(
+                select(Report)
+                .where(Report.id == share.report_id)
+                .options(selectinload(Report.findings))
+            )
+            if report is None:
+                continue
+            by_report[report.id] = ClinicianSharedReportItem(
+                share_id=share.id,
+                report_id=report.id,
+                report=report,
+                patient=patient,
+                scope=share.scope.value,
+                access_level=share.access_level.value,
+                shared_at=share.created_at,
+                expires_at=share.expires_at,
+            )
+            continue
+
+        if share.scope == ConsentScope.PATIENT and share.report_id is None:
+            reports = (
+                await session.scalars(
+                    select(Report)
+                    .where(Report.subject_user_id == share.subject_user_id)
+                    .options(selectinload(Report.findings))
+                )
+            ).all()
+
+            for report in reports:
+                existing = by_report.get(report.id)
+                if existing is not None and existing.scope == ConsentScope.REPORT.value:
+                    continue
+
+                by_report[report.id] = ClinicianSharedReportItem(
+                    share_id=share.id,
+                    report_id=report.id,
+                    report=report,
+                    patient=patient,
+                    scope=share.scope.value,
+                    access_level=share.access_level.value,
+                    shared_at=share.created_at,
+                    expires_at=share.expires_at,
+                )
+
+    return sorted(by_report.values(), key=lambda item: item.shared_at, reverse=True)
+
+
+@dataclass(frozen=True)
+class AuditLogEntry:
+    """Audit log entry for patient view"""
+    event_id: str
+    action: str
+    occurred_at: datetime
+    context: dict
+
+
+async def get_report_audit_log(
+    session: AsyncSession,
+    *,
+    report_id: str,
+    owner_user_id: str,
+    actions: list[str] | None = None,
+) -> list[AuditLogEntry]:
+    """Get audit log for a report owned by owner_user_id.
+    
+    Args:
+        session: Database session
+        report_id: Report ID to audit
+        owner_user_id: Verify this user owns the report
+        actions: Filter by actions (created, revoked, expired). None = all.
+    
+    Returns:
+        List of audit events in DESC chronological order
+    """
+    # Verify ownership
+    report = await session.scalar(select(Report).where(Report.id == report_id))
+    if report is None:
+        raise ReportServiceError("Report not found", 404)
+    
+    if report.subject_user_id != owner_user_id:
+        raise ReportServiceError("Access denied", 403)
+    
+    share_ids = select(ConsentShare.id).where(
+        ConsentShare.subject_user_id == report.subject_user_id,
+        or_(
+            and_(
+                ConsentShare.scope == ConsentScope.REPORT,
+                ConsentShare.report_id == report_id,
+            ),
+            and_(
+                ConsentShare.scope == ConsentScope.PATIENT,
+                ConsentShare.report_id.is_(None),
+            ),
+        ),
+    )
+
+    # Query audit events
+    context_report_id = (AuditEvent.context["report_id"]).as_string()
+    query = select(AuditEvent).where(
+        AuditEvent.resource_type == "consent_share",
+        AuditEvent.resource_id.in_(share_ids),
+        or_(
+            context_report_id.is_(None),
+            context_report_id == report_id,
+        ),
+    )
+    
+    if actions:
+        query = query.where(AuditEvent.action.in_(actions))
+    
+    result = await session.execute(
+        query.order_by(AuditEvent.occurred_at.desc())
+    )
+    events = result.scalars().all()
+    
+    return [
+        AuditLogEntry(
+            event_id=event.id,
+            action=event.action,
+            occurred_at=event.occurred_at,
+            context=event.context or {},
+        )
+        for event in events
+    ]
+
+
+async def cleanup_expired_shares(session: AsyncSession) -> int:
+    """
+    Background job to mark expired shares as revoked and create audit events.
+    
+    Finds all active (not revoked) shares where expires_at <= now, marks them revoked,
+    and creates a SHARE_EXPIRED audit event for each.
+    
+    Returns the count of shares cleaned up.
+    """
+    now = datetime.now(UTC)
+    
+    # Find all active (not revoked) shares that have expired
+    query = select(ConsentShare).where(
+        (ConsentShare.revoked_at.is_(None)) &
+        (ConsentShare.expires_at <= now)
+    )
+    result = await session.execute(query)
+    expired_shares = result.scalars().all()
+    
+    cleaned_count = 0
+    for share in expired_shares:
+        share.revoked_at = now
+        
+        # Create audit event for the expiry
+        grantee = await session.get(User, share.grantee_user_id)
+        
+        context = {
+            "scope": share.scope.value,
+            "access_level": share.access_level.value,
+            "expired_at": now.isoformat(),
+            "grantee_email": grantee.email if grantee else None,
+        }
+        if share.report_id:
+            context["report_id"] = share.report_id
+        
+        await _create_audit_event(
+            session,
+            actor_user_id=None,  # System job, no user actor
+            subject_user_id=share.grantee_user_id,
+            resource_type="consent_share",
+            resource_id=share.id,
+            action="expired",
+            context=context,
+        )
+        
+        cleaned_count += 1
+    
+    await session.commit()
+    return cleaned_count
+
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "Pillow>=10.0.0",
   "openai>=1.40.0",
   "email-validator>=2.0.0",
+  "apscheduler>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Local test package marker for stable imports."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,9 +9,11 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = BACKEND_ROOT.parent
 
-if str(BACKEND_ROOT) not in sys.path:
-    sys.path.insert(0, str(BACKEND_ROOT))
+for path in (str(PROJECT_ROOT), str(BACKEND_ROOT)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
 
 from app.db.base import Base  # noqa: E402
 from tests.factories import PersistenceFactory  # noqa: E402

--- a/backend/tests/support/__init__.py
+++ b/backend/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test harness utilities for consent-sharing integration tests."""

--- a/backend/tests/support/consent_api.py
+++ b/backend/tests/support/consent_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db.models import Report, User
+from app.main import create_app
+from app.services.auth import hash_password
+from tests.factories import PersistenceFactory
+
+
+@dataclass
+class ConsentApiHarness:
+    client: TestClient
+    session_factory: sessionmaker
+
+
+@pytest.fixture()
+def consent_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ConsentApiHarness:
+    db_path = tmp_path / "consent-api.sqlite3"
+    sync_database_url = f"sqlite:///{db_path.resolve().as_posix()}"
+    async_database_url = f"sqlite+aiosqlite:///{db_path.resolve().as_posix()}"
+
+    monkeypatch.setenv("DATABASE_URL", async_database_url)
+    monkeypatch.setenv("AUTH_SECRET_KEY", "reportx-test-auth-secret-key-with-32-bytes")
+
+    engine = create_engine(sync_database_url, future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield ConsentApiHarness(client=client, session_factory=session_factory)
+
+    engine.dispose()
+
+
+def seed_user(
+    session: Session,
+    *,
+    email: str,
+    role: str,
+    password: str = "Password123!",
+    display_name: str | None = None,
+) -> User:
+    factory = PersistenceFactory(session)
+    user = factory.create_user(
+        email=email,
+        display_name=display_name or email.split("@")[0],
+        password_hash=hash_password(password),
+        roles=[role],
+    )
+    session.commit()
+    return user
+
+
+def login(consent_api: ConsentApiHarness, *, email: str, password: str = "Password123!") -> str:
+    response = consent_api.client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def seed_report(session: Session, *, subject_email: str, created_by_email: str) -> Report:
+    factory = PersistenceFactory(session)
+    subject = session.scalar(select(User).where(User.email == subject_email))
+    created_by = session.scalar(select(User).where(User.email == created_by_email))
+    assert subject is not None
+    assert created_by is not None
+    report = factory.create_report(subject=subject, created_by=created_by)
+    session.commit()
+    return report
+
+
+def auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}

--- a/backend/tests/test_audit_log_retrieval.py
+++ b/backend/tests/test_audit_log_retrieval.py
@@ -72,7 +72,10 @@ def _get_audit_log(
 
 def _parse_occurred_at(value: str) -> datetime:
     # FastAPI may emit UTC timestamps with a trailing Z.
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def test_patient_can_retrieve_audit_log_for_own_report(consent_api: ConsentApiHarness) -> None:

--- a/backend/tests/test_audit_log_retrieval.py
+++ b/backend/tests/test_audit_log_retrieval.py
@@ -1,0 +1,369 @@
+"""Integration tests for patient audit log retrieval endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(*, days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _share_report(
+    consent_api: ConsentApiHarness,
+    *,
+    patient_token: str,
+    report_id: str,
+    clinician_email: str,
+    scope: str = "report",
+    access_level: str = "read",
+) -> dict:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": scope,
+            "access_level": access_level,
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _revoke_share(
+    consent_api: ConsentApiHarness,
+    *,
+    patient_token: str,
+    report_id: str,
+    clinician_email: str,
+) -> None:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share/revoke",
+        headers=auth_headers(patient_token),
+        json={"clinician_email": clinician_email},
+    )
+    assert response.status_code == 204, response.text
+
+
+def _get_audit_log(
+    consent_api: ConsentApiHarness,
+    *,
+    patient_token: str,
+    report_id: str,
+    action: str | None = None,
+):
+    suffix = f"?action={action}" if action else ""
+    return consent_api.client.get(
+        f"/api/v1/audit/reports/{report_id}{suffix}",
+        headers=auth_headers(patient_token),
+    )
+
+
+def _parse_occurred_at(value: str) -> datetime:
+    # FastAPI may emit UTC timestamps with a trailing Z.
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def test_patient_can_retrieve_audit_log_for_own_report(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-own@example.com"
+    clinician_email = "clinician-own@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+    )
+
+    assert response.status_code == 200, response.text
+    rows = response.json()
+    assert isinstance(rows, list)
+    assert len(rows) >= 1
+    assert any(row["action"] == "created" for row in rows)
+
+
+def test_audit_events_are_ordered_newest_first(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-order@example.com"
+    clinician_email = "clinician-order@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+    _revoke_share(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+    )
+    assert response.status_code == 200, response.text
+
+    rows = response.json()
+    assert len(rows) >= 2
+    for idx in range(len(rows) - 1):
+        assert _parse_occurred_at(rows[idx]["occurred_at"]) >= _parse_occurred_at(
+            rows[idx + 1]["occurred_at"]
+        )
+
+
+def test_created_and_revoked_events_include_context_fields(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-context@example.com"
+    clinician_email = "clinician-context@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+        access_level="comment",
+    )
+    _revoke_share(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+    )
+    assert response.status_code == 200, response.text
+
+    rows = response.json()
+    created_event = next((row for row in rows if row["action"] == "created"), None)
+    revoked_event = next((row for row in rows if row["action"] == "revoked"), None)
+    assert created_event is not None
+    assert revoked_event is not None
+
+    created_context = created_event["context"]
+    assert created_context["scope"] == "report"
+    assert created_context["access_level"] == "comment"
+    assert created_context["grantee_email"] == clinician_email
+    assert created_context["report_id"] == report.id
+    assert "expires_at" in created_context
+
+    revoked_context = revoked_event["context"]
+    assert revoked_context["scope"] == "report"
+    assert revoked_context["access_level"] == "comment"
+    assert revoked_context["grantee_email"] == clinician_email
+    assert revoked_context["report_id"] == report.id
+
+
+def test_non_owner_access_to_audit_log_is_denied(consent_api: ConsentApiHarness) -> None:
+    owner_email = "patient-owner@example.com"
+    other_patient_email = "patient-other@example.com"
+
+    with consent_api.session_factory() as session:
+        owner = seed_user(session, email=owner_email, role="patient")
+        seed_user(session, email=other_patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=owner.email,
+            created_by_email=owner.email,
+        )
+
+    other_token = login(consent_api, email=other_patient_email)
+    forbidden = _get_audit_log(
+        consent_api,
+        patient_token=other_token,
+        report_id=report.id,
+    )
+
+    assert forbidden.status_code == 403
+
+
+def test_audit_log_action_filter_returns_only_requested_action(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-filter@example.com"
+    clinician_email = "clinician-filter@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+    _revoke_share(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        clinician_email=clinician_email,
+    )
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report.id,
+        action="revoked",
+    )
+
+    assert response.status_code == 200, response.text
+    rows = response.json()
+    assert len(rows) >= 1
+    assert all(row["action"] == "revoked" for row in rows)
+
+
+def test_audit_log_excludes_events_from_other_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-scope@example.com"
+    clinician_email = "clinician-scope@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+        report_b = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_a.id,
+        clinician_email=clinician_email,
+    )
+    _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_b.id,
+        clinician_email=clinician_email,
+    )
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_a.id,
+    )
+    assert response.status_code == 200, response.text
+
+    created_rows = [row for row in response.json() if row["action"] == "created"]
+    assert any(row["context"].get("report_id") == report_a.id for row in created_rows)
+
+    unrelated_events = [
+        row
+        for row in created_rows
+        if row["context"].get("report_id") != report_a.id
+    ]
+    assert unrelated_events == []
+
+
+def test_patient_scope_view_events_do_not_leak_across_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-view-leak@example.com"
+    clinician_email = "clinician-view-leak@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+        report_b = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    share = _share_report(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_a.id,
+        clinician_email=clinician_email,
+        scope="patient",
+    )
+    assert share["scope"] == "patient"
+
+    clinician_token = login(consent_api, email=clinician_email)
+    access_report_b = consent_api.client.get(
+        f"/api/v1/reports/{report_b.id}",
+        headers=auth_headers(clinician_token),
+    )
+    assert access_report_b.status_code == 200, access_report_b.text
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_a.id,
+    )
+    assert response.status_code == 200, response.text
+
+    leaked_view_events = [
+        row
+        for row in response.json()
+        if row["action"] == "view" and row["context"].get("report_id") == report_b.id
+    ]
+    assert leaked_view_events == []

--- a/backend/tests/test_audit_sharing.py
+++ b/backend/tests/test_audit_sharing.py
@@ -1,0 +1,231 @@
+"""Integration tests for audit events emitted by share and revoke operations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(*, days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _share_report(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_token: str,
+    clinician_email: str,
+    scope: str = "report",
+    access_level: str = "read",
+) -> dict:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": scope,
+            "access_level": access_level,
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _revoke_share(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_token: str,
+    clinician_email: str,
+) -> None:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share/revoke",
+        headers=auth_headers(patient_token),
+        json={"clinician_email": clinician_email},
+    )
+    assert response.status_code == 204, response.text
+
+
+def _audit_rows(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_token: str,
+) -> list[dict]:
+    response = consent_api.client.get(
+        f"/api/v1/audit/reports/{report_id}",
+        headers=auth_headers(patient_token),
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert isinstance(payload, list)
+    return payload
+
+
+def _parse_occurred_at(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def test_share_creation_emits_created_audit_with_required_context(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-audit-created@example.com"
+    clinician_email = "clinician-audit-created@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        scope="report",
+        access_level="comment",
+    )
+
+    rows = _audit_rows(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+    )
+    created = next((row for row in rows if row["action"] == "created"), None)
+    assert created is not None
+
+    context = created["context"]
+    assert context["scope"] == "report"
+    assert context["access_level"] == "comment"
+    assert context["grantee_email"] == clinician_email
+    assert context["report_id"] == report.id
+    assert "expires_at" in context
+
+
+def test_patient_scope_share_audit_context_marks_scope_patient(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-audit-patient-scope@example.com"
+    clinician_email = "clinician-audit-patient-scope@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        scope="patient",
+    )
+
+    rows = _audit_rows(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+    )
+    created = next((row for row in rows if row["action"] == "created"), None)
+    assert created is not None
+    assert created["context"]["scope"] == "patient"
+    assert created["context"]["report_id"] is None
+
+
+def test_revoke_emits_revoked_audit_with_required_context(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-audit-revoke@example.com"
+    clinician_email = "clinician-audit-revoke@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        access_level="comment",
+    )
+    _revoke_share(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+
+    rows = _audit_rows(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+    )
+    assert any(row["action"] == "created" for row in rows)
+    assert any(row["action"] == "revoked" for row in rows)
+
+    revoked = next((row for row in rows if row["action"] == "revoked"), None)
+    assert revoked is not None
+    context = revoked["context"]
+    assert context["scope"] == "report"
+    assert context["access_level"] == "comment"
+    assert context["grantee_email"] == clinician_email
+    assert context["report_id"] == report.id
+
+
+def test_audit_occurred_at_for_created_event_is_recent(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-audit-timestamp@example.com"
+    clinician_email = "clinician-audit-timestamp@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    before = datetime.now(UTC)
+    _share_report(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+    after = datetime.now(UTC)
+
+    rows = _audit_rows(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+    )
+    created = next((row for row in rows if row["action"] == "created"), None)
+    assert created is not None
+
+    occurred_at = _parse_occurred_at(created["occurred_at"])
+    assert before <= occurred_at <= after

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -704,7 +705,7 @@ def test_app_lifespan_runs_alembic_with_async_subprocess(auth_api: AuthApiHarnes
 
     async def fake_create_subprocess_exec(*args, **kwargs):
         called["count"] += 1
-        assert args[:3] == ("alembic", "upgrade", "head")
+        assert args[:5] == (sys.executable, "-m", "alembic", "upgrade", "head")
         return FakeProcess()
 
     monkeypatch.setenv("ALEMBIC_STARTUP_TIMEOUT_SECONDS", "5")

--- a/backend/tests/test_clinician_endpoints.py
+++ b/backend/tests/test_clinician_endpoints.py
@@ -1,0 +1,332 @@
+"""Integration tests for clinician shared-reports discovery endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import ConsentShare
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def test_harness_fixture_is_available(consent_api: ConsentApiHarness) -> None:
+    assert consent_api.client is not None
+    assert consent_api.session_factory is not None
+
+
+def test_non_clinician_cannot_list_shared_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-non-clinician@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+
+    patient_token = login(consent_api, email=patient_email)
+    response = consent_api.client.get(
+        "/api/v1/reports/shared-reports",
+        headers=auth_headers(patient_token),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only clinicians may view shared reports"
+
+
+def _share_report(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_token: str,
+    clinician_email: str,
+    scope: str = "report",
+    access_level: str = "read",
+) -> dict:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        json={
+            "clinician_email": clinician_email,
+            "scope": scope,
+            "access_level": access_level,
+            "expires_at": (datetime.now(UTC) + timedelta(days=7)).isoformat(),
+        },
+        headers=auth_headers(patient_token),
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _list_shared_reports(consent_api: ConsentApiHarness, *, clinician_token: str) -> list[dict]:
+    response = consent_api.client.get(
+        "/api/v1/reports/shared-reports",
+        headers=auth_headers(clinician_token),
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert isinstance(payload, list)
+    return payload
+
+
+def test_clinician_can_list_actively_shared_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-list@example.com"
+    clinician_email = "clinician-list@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_1 = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+        report_2 = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report_1.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        access_level="read",
+    )
+    _share_report(
+        consent_api,
+        report_id=report_2.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        access_level="comment",
+    )
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    report_ids = {item["report"]["id"] for item in payload}
+    assert report_ids == {report_1.id, report_2.id}
+
+
+def test_unshared_reports_are_not_visible_to_clinician(consent_api: ConsentApiHarness) -> None:
+    patient_shared_email = "patient-shared@example.com"
+    patient_private_email = "patient-private@example.com"
+    clinician_email = "clinician-unshared@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_shared_email, role="patient")
+        seed_user(session, email=patient_private_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        shared_report = seed_report(
+            session,
+            subject_email=patient_shared_email,
+            created_by_email=patient_shared_email,
+        )
+        unshared_report = seed_report(
+            session,
+            subject_email=patient_private_email,
+            created_by_email=patient_private_email,
+        )
+
+    shared_patient_token = login(consent_api, email=patient_shared_email)
+    _share_report(
+        consent_api,
+        report_id=shared_report.id,
+        patient_token=shared_patient_token,
+        clinician_email=clinician_email,
+    )
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    report_ids = {item["report"]["id"] for item in payload}
+    assert report_ids == {shared_report.id}
+    assert unshared_report.id not in report_ids
+
+
+def test_expired_and_revoked_shares_are_not_listed(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-expired@example.com"
+    clinician_email = "clinician-expired@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        active_report = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+        expired_report = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+        revoked_report = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    active_share = _share_report(
+        consent_api,
+        report_id=active_report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+    expired_share = _share_report(
+        consent_api,
+        report_id=expired_report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+    _share_report(
+        consent_api,
+        report_id=revoked_report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+
+    revoke_response = consent_api.client.post(
+        f"/api/v1/reports/{revoked_report.id}/share/revoke",
+        json={"clinician_email": clinician_email},
+        headers=auth_headers(patient_token),
+    )
+    assert revoke_response.status_code == 204, revoke_response.text
+
+    with consent_api.session_factory() as session:
+        expired_row = session.scalar(
+            select(ConsentShare).where(ConsentShare.id == expired_share["id"])
+        )
+        assert expired_row is not None
+        expired_row.expires_at = datetime.now(UTC) - timedelta(hours=1)
+        session.commit()
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    report_ids = {item["report"]["id"] for item in payload}
+    assert active_report.id in report_ids
+    assert expired_report.id not in report_ids
+    assert revoked_report.id not in report_ids
+    assert active_share["id"] in {item["share_id"] for item in payload}
+
+
+def test_shared_reports_include_patient_profile_fields(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-profile@example.com"
+    clinician_email = "clinician-profile@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(
+            session,
+            email=patient_email,
+            role="patient",
+            display_name="Jane Patient",
+        )
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    item = next(entry for entry in payload if entry["report"]["id"] == report.id)
+    patient_payload = item["patient"]
+    assert patient_payload["id"] == patient.id
+    assert patient_payload["email"] == patient_email
+    assert patient_payload["display_name"] == "Jane Patient"
+    assert "preferred_language" in patient_payload
+
+
+def test_patient_scope_share_lists_all_patient_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-scope-list@example.com"
+    clinician_email = "clinician-scope-list@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+        report_b = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report_a.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        scope="patient",
+    )
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    ids = {item["report"]["id"] for item in payload}
+    assert ids == {report_a.id, report_b.id}
+
+
+def test_overlap_patient_and_report_scope_is_deduped_by_report(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-overlap@example.com"
+    clinician_email = "clinician-overlap@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+        report_b = seed_report(
+            session,
+            subject_email=patient_email,
+            created_by_email=patient_email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    _share_report(
+        consent_api,
+        report_id=report_a.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        scope="patient",
+    )
+    _share_report(
+        consent_api,
+        report_id=report_a.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+        scope="report",
+    )
+
+    clinician_token = login(consent_api, email=clinician_email)
+    payload = _list_shared_reports(consent_api, clinician_token=clinician_token)
+
+    ids = [item["report"]["id"] for item in payload]
+    assert set(ids) == {report_a.id, report_b.id}
+    assert ids.count(report_a.id) == 1
+    report_a_row = next(item for item in payload if item["report"]["id"] == report_a.id)
+    assert report_a_row["scope"] == "report"

--- a/backend/tests/test_expired_share_cleanup.py
+++ b/backend/tests/test_expired_share_cleanup.py
@@ -1,0 +1,179 @@
+"""Integration tests for background cleanup of expired consent shares."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import AuditEvent, ConsentAccessLevel, ConsentScope, ConsentShare
+from app.services.reports import cleanup_expired_shares
+from tests.support.consent_api import ConsentApiHarness, consent_api, seed_report, seed_user
+
+
+def _run_cleanup(consent_api: ConsentApiHarness) -> int:
+    async def _execute() -> int:
+        async with consent_api.client.app.state.database.session_factory() as async_session:
+            return await cleanup_expired_shares(async_session)
+
+    return asyncio.run(_execute())
+
+
+def test_cleanup_revokes_only_active_expired_shares(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-cleanup-count@example.com", role="patient")
+        clinician = seed_user(session, email="clinician-cleanup-count@example.com", role="clinician")
+        clinician_alt = seed_user(session, email="clinician-cleanup-count-alt@example.com", role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+        expired_share = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            scope=ConsentScope.REPORT,
+            access_level=ConsentAccessLevel.READ,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        active_share = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician.id,
+            granted_by_user_id=patient.id,
+            report_id=None,
+            scope=ConsentScope.PATIENT,
+            access_level=ConsentAccessLevel.READ,
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        already_revoked_share = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician_alt.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            scope=ConsentScope.REPORT,
+            access_level=ConsentAccessLevel.READ,
+            expires_at=datetime.now(UTC) - timedelta(hours=2),
+            revoked_at=datetime.now(UTC) - timedelta(minutes=30),
+        )
+        session.add_all([expired_share, active_share, already_revoked_share])
+        session.commit()
+
+        expired_share_id = expired_share.id
+        active_share_id = active_share.id
+        already_revoked_share_id = already_revoked_share.id
+
+    cleaned_count = _run_cleanup(consent_api)
+    assert cleaned_count == 1
+
+    with consent_api.session_factory() as session:
+        expired_row = session.scalar(select(ConsentShare).where(ConsentShare.id == expired_share_id))
+        active_row = session.scalar(select(ConsentShare).where(ConsentShare.id == active_share_id))
+        already_revoked_row = session.scalar(
+            select(ConsentShare).where(ConsentShare.id == already_revoked_share_id)
+        )
+
+        assert expired_row is not None
+        assert active_row is not None
+        assert already_revoked_row is not None
+
+        assert expired_row.revoked_at is not None
+        assert active_row.revoked_at is None
+        assert already_revoked_row.revoked_at is not None
+
+
+def test_cleanup_writes_consent_share_expired_audit_event(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-cleanup-audit@example.com", role="patient")
+        clinician = seed_user(session, email="clinician-cleanup-audit@example.com", role="clinician")
+        clinician_id = clinician.id
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+        expired_share = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            scope=ConsentScope.REPORT,
+            access_level=ConsentAccessLevel.COMMENT,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        session.add(expired_share)
+        session.commit()
+        expired_share_id = expired_share.id
+
+    cleaned_count = _run_cleanup(consent_api)
+    assert cleaned_count == 1
+
+    with consent_api.session_factory() as session:
+        event = session.scalar(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.resource_id == expired_share_id)
+            .where(AuditEvent.action == "expired")
+        )
+
+    assert event is not None
+    assert event.resource_id == expired_share_id
+    assert event.resource_type == "consent_share"
+    assert event.subject_user_id == clinician_id
+
+    context = event.context or {}
+    assert context.get("scope") == "report"
+    assert context.get("access_level") == "comment"
+    assert context.get("report_id") is not None
+    assert context.get("grantee_email") == "clinician-cleanup-audit@example.com"
+    assert "expired_at" in context
+
+
+def test_cleanup_handles_multiple_expired_shares_in_one_run(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-cleanup-multi@example.com", role="patient")
+        clinician_a = seed_user(session, email="clinician-cleanup-a@example.com", role="clinician")
+        clinician_b = seed_user(session, email="clinician-cleanup-b@example.com", role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+        share_a = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician_a.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            scope=ConsentScope.REPORT,
+            access_level=ConsentAccessLevel.READ,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        share_b = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician_b.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            scope=ConsentScope.REPORT,
+            access_level=ConsentAccessLevel.READ,
+            expires_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+        session.add_all([share_a, share_b])
+        session.commit()
+        share_ids = [share_a.id, share_b.id]
+
+    cleaned_count = _run_cleanup(consent_api)
+    assert cleaned_count == 2
+
+    with consent_api.session_factory() as session:
+        events = session.scalars(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.action == "expired")
+            .where(AuditEvent.resource_id.in_(share_ids))
+        ).all()
+
+    assert len(events) == 2

--- a/backend/tests/test_expiry_enforcement.py
+++ b/backend/tests/test_expiry_enforcement.py
@@ -1,0 +1,140 @@
+"""Integration tests for expired-share access enforcement and audit emission."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import AuditEvent, ConsentShare
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(*, days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _create_share(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_token: str,
+    clinician_email: str,
+) -> str:
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _expire_share(consent_api: ConsentApiHarness, *, share_id: str) -> None:
+    with consent_api.session_factory() as session:
+        share = session.scalar(select(ConsentShare).where(ConsentShare.id == share_id))
+        assert share is not None
+        share.expires_at = datetime.now(UTC) - timedelta(hours=1)
+        session.commit()
+
+
+def _fetch_expiry_events(consent_api: ConsentApiHarness, *, share_id: str) -> list[AuditEvent]:
+    with consent_api.session_factory() as session:
+        return session.scalars(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.resource_id == share_id)
+            .where(AuditEvent.action == "expired")
+        ).all()
+
+
+def test_expired_share_denies_access_with_expired_message(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-expiry-deny@example.com"
+    clinician_email = "clinician-expiry-deny@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    share_id = _create_share(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+    _expire_share(consent_api, share_id=share_id)
+
+    clinician_token = login(consent_api, email=clinician_email)
+    denied = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(clinician_token),
+    )
+
+    assert denied.status_code == 403
+    assert "expired" in denied.text.lower()
+
+
+def test_first_expired_access_creates_single_expired_audit_event(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-expiry-audit@example.com"
+    clinician_email = "clinician-expiry-audit@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    share_id = _create_share(
+        consent_api,
+        report_id=report.id,
+        patient_token=patient_token,
+        clinician_email=clinician_email,
+    )
+    _expire_share(consent_api, share_id=share_id)
+
+    clinician_token = login(consent_api, email=clinician_email)
+    first_denied = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(clinician_token),
+    )
+    second_denied = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(clinician_token),
+    )
+
+    assert first_denied.status_code == 403
+    assert second_denied.status_code == 403
+
+    events = _fetch_expiry_events(consent_api, share_id=share_id)
+    assert len(events) == 1
+    event = events[0]
+    assert event.resource_type == "consent_share"
+    assert event.resource_id == share_id
+
+    context = event.context or {}
+    assert context.get("scope") == "report"
+    assert context.get("access_level") == "read"
+    assert "expired_at" in context
+    assert "expires_at" in context

--- a/backend/tests/test_harness_imports.py
+++ b/backend/tests/test_harness_imports.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+
+def test_local_tests_package_imports_factories_module() -> None:
+    module = import_module("tests.factories")
+    assert hasattr(module, "PersistenceFactory")

--- a/backend/tests/test_startup_migrations.py
+++ b/backend/tests/test_startup_migrations.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import main as main_mod
+
+
+@pytest.mark.asyncio
+async def test_run_alembic_migrations_uses_active_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_process = SimpleNamespace(
+        communicate=AsyncMock(return_value=(b"ok", b"")),
+        returncode=0,
+    )
+
+    called_args: dict[str, object] = {}
+
+    async def fake_exec(*args, **kwargs):
+        called_args["args"] = args
+        called_args["kwargs"] = kwargs
+        return fake_process
+
+    monkeypatch.setattr(main_mod.asyncio, "create_subprocess_exec", fake_exec)
+
+    await main_mod._run_alembic_migrations(".", timeout=60)
+
+    args = called_args["args"]
+    assert args[0] == sys.executable
+    assert args[1:5] == ("-m", "alembic", "upgrade", "head")
+
+@pytest.mark.asyncio
+async def test_app_lifespan_defaults_cleanup_interval_to_five_minutes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeScheduler:
+        def add_job(self, _func, _trigger, *, minutes: int, **_kwargs):
+            captured["minutes"] = minutes
+
+        def start(self):
+            captured["started"] = True
+
+        def shutdown(self):
+            captured["shutdown"] = True
+
+    class FakeDatabase:
+        def session_factory(self):
+            raise AssertionError("session_factory should not be called in this test")
+
+        async def dispose(self):
+            captured["disposed"] = True
+
+    async def fake_run_alembic_migrations(_project_root: str, timeout: int):
+        captured["timeout"] = timeout
+
+    fake_app = SimpleNamespace(state=SimpleNamespace(database=FakeDatabase()))
+
+    monkeypatch.delenv("CLEANUP_INTERVAL_MINUTES", raising=False)
+    monkeypatch.setattr(main_mod, "AsyncIOScheduler", lambda: FakeScheduler())
+    monkeypatch.setattr(main_mod, "_run_alembic_migrations", fake_run_alembic_migrations)
+
+    async with main_mod.app_lifespan(fake_app):
+        pass
+
+    assert captured["minutes"] == 5
+    assert captured["started"] is True
+    assert captured["shutdown"] is True
+    assert captured["disposed"] is True

--- a/backend/tests/test_verified_clinician.py
+++ b/backend/tests/test_verified_clinician.py
@@ -1,0 +1,73 @@
+"""Integration tests for clinician-role validation on report sharing."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(*, days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def test_share_with_non_clinician_role_is_rejected(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        seed_user(session, email="other_patient@example.com", role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient.email)
+    share_response = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": "other_patient@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+
+    assert share_response.status_code == 400
+    assert "clinician" in share_response.text.lower()
+
+
+def test_share_with_clinician_role_succeeds(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-share-ok@example.com", role="patient")
+        clinician = seed_user(session, email="clinician-share-ok@example.com", role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient.email)
+    share_response = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician.email,
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+
+    assert share_response.status_code == 201, share_response.text
+    payload = share_response.json()
+    assert payload["clinician_email"] == clinician.email
+    assert payload["scope"] == "report"
+    assert payload["access_level"] == "read"

--- a/backend/tests/test_view_audit.py
+++ b/backend/tests/test_view_audit.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import AuditEvent
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def test_non_owner_report_access_creates_view_audit_event(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-view@example.com", role="patient")
+        clinician = seed_user(session, email="clinician-view@example.com", role="clinician")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient-view@example.com")
+    share = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": "clinician-view@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert share.status_code == 201, share.text
+    share_id = share.json()["id"]
+
+    clinician_token = login(consent_api, email="clinician-view@example.com")
+    read = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(clinician_token),
+    )
+    assert read.status_code == 200, read.text
+
+    with consent_api.session_factory() as session:
+        rows = session.scalars(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.resource_id == share_id)
+            .where(AuditEvent.action == "view")
+        ).all()
+
+    assert len(rows) == 1
+    event = rows[0]
+    assert event.actor_user_id == clinician.id
+    assert event.subject_user_id == clinician.id
+
+
+def test_owner_report_access_does_not_create_view_audit_event(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-owner-view@example.com", role="patient")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient-owner-view@example.com")
+    read = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(patient_token),
+    )
+    assert read.status_code == 200, read.text
+
+    with consent_api.session_factory() as session:
+        rows = session.scalars(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.action == "view")
+        ).all()
+
+    assert all((row.context or {}).get("report_id") != report.id for row in rows)

--- a/docs/superpowers/plans/2026-04-09-consent-sharing-stabilization.md
+++ b/docs/superpowers/plans/2026-04-09-consent-sharing-stabilization.md
@@ -1,0 +1,753 @@
+# Consent Sharing Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix consent-sharing correctness and reliability issues by aligning audit scoping, audit taxonomy, API contract, and failing tests.
+
+**Architecture:** Keep the existing backend module boundaries (`app/services/reports.py`, `app/dependencies/reports.py`, `app/routers/reports.py`) and add a reusable consent integration test harness for deterministic API tests. Implement behavior fixes in service layer first, then align tests and endpoint expectations to the canonical route. Preserve current domain model and avoid unrelated refactors.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy (async + sync test setup), pytest, TestClient, SQLite
+
+---
+
+## Scope Check
+
+This is a single subsystem plan (consent sharing + audit behavior stabilization). No decomposition is required.
+
+## File Structure (Lock Before Coding)
+
+### Create
+- `backend/tests/__init__.py`
+  - Ensure local `tests` package resolves before third-party `tests` modules.
+- `backend/tests/support/__init__.py`
+  - Mark support package for shared fixtures/helpers.
+- `backend/tests/support/consent_api.py`
+  - Reusable TestClient + DB harness and seed/login helpers for consent-related API tests.
+- `backend/tests/test_harness_imports.py`
+  - Regression test for local test package import resolution.
+
+### Modify
+- `backend/tests/conftest.py`
+  - Add deterministic test import path handling.
+- `backend/app/services/reports.py`
+  - Fix report-scoped audit retrieval query.
+  - Normalize cleanup audit `resource_type`.
+- `backend/tests/test_clinician_endpoints.py`
+  - Convert to harness-driven tests and canonical endpoint path.
+- `backend/tests/test_audit_log_retrieval.py`
+  - Convert to harness-driven tests and add report-scope leak-prevention assertion.
+- `backend/tests/test_verified_clinician.py`
+  - Replace fixture mismatch with harness-based integration tests.
+- `backend/tests/test_audit_sharing.py`
+  - Replace fixture mismatch with harness-based integration tests.
+- `backend/tests/test_expiry_enforcement.py`
+  - Replace fixture mismatch with harness-based integration tests.
+- `backend/tests/test_expired_share_cleanup.py`
+  - Replace invalid schema references (`AuditEvent.share_id`) and fixture misuse.
+
+### Keep Unchanged
+- `backend/app/routers/reports.py`
+  - Keep canonical endpoint route under reports router (`/api/v1/reports/shared-reports`).
+
+---
+
+### Task 1: Stabilize Local Test Imports
+
+**Files:**
+- Create: `backend/tests/__init__.py`
+- Create: `backend/tests/test_harness_imports.py`
+- Modify: `backend/tests/conftest.py`
+- Test: `backend/tests/test_harness_imports.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/test_harness_imports.py
+from importlib import import_module
+
+
+def test_local_tests_package_imports_factories_module() -> None:
+    module = import_module("tests.factories")
+    assert hasattr(module, "PersistenceFactory")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q backend/tests/test_harness_imports.py`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tests.factories'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/tests/__init__.py
+"""Local test package marker for stable imports."""
+```
+
+```python
+# backend/tests/conftest.py (top section)
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = Path(__file__).resolve().parent
+
+for path in (str(BACKEND_ROOT), str(TESTS_ROOT.parent)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q backend/tests/test_harness_imports.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/__init__.py backend/tests/conftest.py backend/tests/test_harness_imports.py
+git commit -m "test: stabilize local tests package imports"
+```
+
+---
+
+### Task 2: Build Consent API Integration Harness
+
+**Files:**
+- Create: `backend/tests/support/__init__.py`
+- Create: `backend/tests/support/consent_api.py`
+- Test: `backend/tests/test_clinician_endpoints.py`
+
+- [ ] **Step 1: Write the failing test that depends on the new harness**
+
+```python
+# backend/tests/test_clinician_endpoints.py (new top-level smoke test)
+from tests.support.consent_api import consent_api
+
+
+def test_harness_fixture_is_available(consent_api) -> None:
+    assert consent_api.client is not None
+    assert consent_api.session_factory is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py::test_harness_fixture_is_available`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tests.support.consent_api'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/tests/support/__init__.py
+"""Shared test harness utilities for consent-sharing integration tests."""
+```
+
+```python
+# backend/tests/support/consent_api.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db.models import Report, User
+from app.main import create_app
+from app.services.auth import hash_password
+from tests.factories import PersistenceFactory
+
+
+@dataclass
+class ConsentApiHarness:
+    client: TestClient
+    session_factory: sessionmaker
+
+
+@pytest.fixture()
+def consent_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ConsentApiHarness:
+    db_path = tmp_path / "consent-api.sqlite3"
+    sync_database_url = f"sqlite:///{db_path.resolve().as_posix()}"
+    async_database_url = f"sqlite+aiosqlite:///{db_path.resolve().as_posix()}"
+
+    monkeypatch.setenv("DATABASE_URL", async_database_url)
+    monkeypatch.setenv("AUTH_SECRET_KEY", "reportx-test-auth-secret-key-with-32-bytes")
+
+    engine = create_engine(sync_database_url, future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield ConsentApiHarness(client=client, session_factory=session_factory)
+
+    engine.dispose()
+
+
+def seed_user(session: Session, *, email: str, role: str, password: str = "Password123!", display_name: str | None = None) -> User:
+    factory = PersistenceFactory(session)
+    user = factory.create_user(
+        email=email,
+        display_name=display_name or email.split("@")[0],
+        password_hash=hash_password(password),
+        roles=[role],
+    )
+    session.commit()
+    return user
+
+
+def login(consent_api: ConsentApiHarness, *, email: str, password: str = "Password123!") -> str:
+    response = consent_api.client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def seed_report(session: Session, *, subject_email: str, created_by_email: str) -> Report:
+    factory = PersistenceFactory(session)
+    subject = session.scalar(select(User).where(User.email == subject_email))
+    created_by = session.scalar(select(User).where(User.email == created_by_email))
+    assert subject is not None
+    assert created_by is not None
+    report = factory.create_report(subject=subject, created_by=created_by)
+    session.commit()
+    return report
+
+
+def auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py::test_harness_fixture_is_available`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/support/__init__.py backend/tests/support/consent_api.py backend/tests/test_clinician_endpoints.py
+git commit -m "test: add reusable consent API integration harness"
+```
+
+---
+
+### Task 3: Fix Report-Scoped Audit Retrieval
+
+**Files:**
+- Modify: `backend/app/services/reports.py`
+- Modify: `backend/tests/test_audit_log_retrieval.py`
+- Test: `backend/tests/test_audit_log_retrieval.py`
+
+- [ ] **Step 1: Write the failing test for cross-report leak prevention**
+
+```python
+# backend/tests/test_audit_log_retrieval.py (add test)
+def test_audit_log_excludes_events_from_other_reports(consent_api):
+    from tests.support.consent_api import auth_headers, login, seed_report, seed_user
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        clinician = seed_user(session, email="clinician@example.com", role="clinician")
+        report_a = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+        report_b = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+        session.execute(
+            """
+            INSERT INTO consent_shares (id, subject_user_id, grantee_user_id, granted_by_user_id, report_id, scope, access_level, expires_at, created_at, updated_at)
+            VALUES (:id, :subject_user_id, :grantee_user_id, :granted_by_user_id, :report_id, 'report', 'read', datetime('now', '+7 day'), datetime('now'), datetime('now'))
+            """,
+            {
+                "id": "00000000-0000-0000-0000-000000000101",
+                "subject_user_id": patient.id,
+                "grantee_user_id": clinician.id,
+                "granted_by_user_id": patient.id,
+                "report_id": report_b.id,
+            },
+        )
+        session.execute(
+            """
+            INSERT INTO audit_events (id, actor_user_id, subject_user_id, resource_type, resource_id, action, context, occurred_at)
+            VALUES (:id, :actor_user_id, :subject_user_id, 'consent_share', :resource_id, 'created', '{}', datetime('now'))
+            """,
+            {
+                "id": "00000000-0000-0000-0000-000000000201",
+                "actor_user_id": patient.id,
+                "subject_user_id": clinician.id,
+                "resource_id": "00000000-0000-0000-0000-000000000101",
+            },
+        )
+        session.commit()
+
+    patient_token = login(consent_api, email="patient@example.com")
+    response = consent_api.client.get(
+        f"/api/v1/audit/reports/{report_a.id}",
+        headers=auth_headers(patient_token),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py::test_audit_log_excludes_events_from_other_reports`
+Expected: FAIL because unrelated report event is currently returned
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/services/reports.py (imports)
+from sqlalchemy import and_, or_, select
+```
+
+```python
+# backend/app/services/reports.py (inside get_report_audit_log)
+share_ids = select(ConsentShare.id).where(
+    ConsentShare.subject_user_id == owner_user_id,
+    or_(
+        and_(
+            ConsentShare.scope == ConsentScope.REPORT,
+            ConsentShare.report_id == report_id,
+        ),
+        and_(
+            ConsentShare.scope == ConsentScope.PATIENT,
+            ConsentShare.report_id.is_(None),
+        ),
+    ),
+)
+
+query = select(AuditEvent).where(
+    AuditEvent.resource_type == "consent_share",
+    AuditEvent.resource_id.in_(share_ids),
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py::test_audit_log_excludes_events_from_other_reports`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/reports.py backend/tests/test_audit_log_retrieval.py
+git commit -m "fix(reports): scope audit log events to target report"
+```
+
+---
+
+### Task 4: Normalize Expired Cleanup Audit Taxonomy
+
+**Files:**
+- Modify: `backend/app/services/reports.py`
+- Modify: `backend/tests/test_expired_share_cleanup.py`
+- Test: `backend/tests/test_expired_share_cleanup.py`
+
+- [ ] **Step 1: Write the failing test for cleanup taxonomy**
+
+```python
+# backend/tests/test_expired_share_cleanup.py (add test)
+def test_cleanup_writes_consent_share_resource_type(consent_api):
+    import asyncio
+    from datetime import UTC, datetime, timedelta
+    from sqlalchemy import select
+
+    from app.db.models import AuditEvent, ConsentShare, User
+    from app.services.reports import cleanup_expired_shares
+    from tests.support.consent_api import seed_report, seed_user
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        clinician = seed_user(session, email="clinician@example.com", role="clinician")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+        share = ConsentShare(
+            subject_user_id=patient.id,
+            grantee_user_id=clinician.id,
+            granted_by_user_id=patient.id,
+            report_id=report.id,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        session.add(share)
+        session.commit()
+
+    async def _run_cleanup() -> None:
+        async with consent_api.client.app.state.database.session() as async_session:
+            await cleanup_expired_shares(async_session)
+
+    asyncio.run(_run_cleanup())
+
+    with consent_api.session_factory() as session:
+        event = session.scalar(
+            select(AuditEvent)
+            .where(AuditEvent.resource_id == share.id)
+            .where(AuditEvent.action == "expired")
+        )
+        assert event is not None
+        assert event.resource_type == "consent_share"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q backend/tests/test_expired_share_cleanup.py::test_cleanup_writes_consent_share_resource_type`
+Expected: FAIL because `resource_type` is currently `share`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/services/reports.py (inside cleanup_expired_shares -> _create_audit_event call)
+await _create_audit_event(
+    session,
+    actor_user_id=None,
+    subject_user_id=share.subject_user_id,
+    resource_type="consent_share",
+    resource_id=share.id,
+    action="expired",
+    context=context,
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q backend/tests/test_expired_share_cleanup.py::test_cleanup_writes_consent_share_resource_type`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/reports.py backend/tests/test_expired_share_cleanup.py
+git commit -m "fix(reports): use consent_share taxonomy for cleanup expiry audits"
+```
+
+---
+
+### Task 5: Align Clinician Shared-Reports Contract and Tests
+
+**Files:**
+- Modify: `backend/tests/test_clinician_endpoints.py`
+- Test: `backend/tests/test_clinician_endpoints.py`
+
+- [ ] **Step 1: Write/update failing test to canonical route**
+
+```python
+# backend/tests/test_clinician_endpoints.py (replace endpoint usage)
+response = consent_api.client.get(
+    "/api/v1/reports/shared-reports",
+    headers=auth_headers(clinician_token),
+)
+assert response.status_code == 200
+```
+
+- [ ] **Step 2: Run test to verify current file fails for old route assumptions**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py -k shared_reports`
+Expected: FAIL before file conversion because tests still target `/api/v1/clinician/shared-reports`
+
+- [ ] **Step 3: Write minimal implementation (convert file to harness-driven sync integration tests)**
+
+```python
+# backend/tests/test_clinician_endpoints.py (core pattern)
+from tests.support.consent_api import auth_headers, consent_api, login, seed_report, seed_user
+
+
+def test_clinician_can_list_only_active_shared_reports(consent_api):
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        clinician = seed_user(session, email="clinician@example.com", role="clinician")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient@example.com")
+    create_share = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": "clinician@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    )
+    assert create_share.status_code == 201, create_share.text
+
+    clinician_token = login(consent_api, email="clinician@example.com")
+    response = consent_api.client.get(
+        "/api/v1/reports/shared-reports",
+        headers=auth_headers(clinician_token),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["report_id"] == report.id
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_clinician_endpoints.py
+git commit -m "test(reports): align clinician shared reports tests to canonical endpoint"
+```
+
+---
+
+### Task 6: Rewrite Audit Log Retrieval Tests to Valid Harness + Scope Assertions
+
+**Files:**
+- Modify: `backend/tests/test_audit_log_retrieval.py`
+- Test: `backend/tests/test_audit_log_retrieval.py`
+
+- [ ] **Step 1: Write failing test for action filter + owner restriction + scope**
+
+```python
+# backend/tests/test_audit_log_retrieval.py (core assertions)
+assert response.status_code == 200
+assert all(row["action"] == "revoked" for row in response.json())
+```
+
+```python
+# backend/tests/test_audit_log_retrieval.py (non-owner assertion)
+assert forbidden.status_code == 403
+```
+
+```python
+# backend/tests/test_audit_log_retrieval.py (scope assertion)
+assert unrelated_events == []
+```
+
+- [ ] **Step 2: Run tests to verify failures before full conversion**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py`
+Expected: FAIL due to async fixture mismatch and invalid setup assumptions
+
+- [ ] **Step 3: Write minimal implementation (replace file with harness-driven integration tests)**
+
+```python
+# backend/tests/test_audit_log_retrieval.py (example test body)
+from tests.support.consent_api import auth_headers, login, seed_report, seed_user
+
+
+def test_patient_can_filter_audit_log_by_action(consent_api):
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        clinician = seed_user(session, email="clinician@example.com", role="clinician")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient@example.com")
+    share_response = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": "clinician@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    )
+    assert share_response.status_code == 201
+
+    revoke_response = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share/revoke",
+        headers=auth_headers(patient_token),
+        json={"clinician_email": "clinician@example.com"},
+    )
+    assert revoke_response.status_code == 204
+
+    filtered = consent_api.client.get(
+        f"/api/v1/audit/reports/{report.id}?action=revoked",
+        headers=auth_headers(patient_token),
+    )
+    assert filtered.status_code == 200
+    rows = filtered.json()
+    assert len(rows) >= 1
+    assert all(row["action"] == "revoked" for row in rows)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_audit_log_retrieval.py
+git commit -m "test(audit): rewrite audit retrieval coverage with consent harness"
+```
+
+---
+
+### Task 7: Replace Remaining Broken Consent Tests With Valid Integration Coverage
+
+**Files:**
+- Modify: `backend/tests/test_verified_clinician.py`
+- Modify: `backend/tests/test_audit_sharing.py`
+- Modify: `backend/tests/test_expiry_enforcement.py`
+- Modify: `backend/tests/test_expired_share_cleanup.py`
+- Test: these four files
+
+- [ ] **Step 1: Write failing test targets for each behavior group**
+
+```python
+# verified clinician
+assert share_response.status_code == 400
+assert "clinician" in share_response.text.lower()
+```
+
+```python
+# share/revoke audit
+assert any(event["action"] == "created" for event in audit_rows)
+assert any(event["action"] == "revoked" for event in audit_rows)
+```
+
+```python
+# expiry enforcement
+assert denied.status_code == 403
+assert "expired" in denied.text.lower()
+```
+
+```python
+# cleanup schema
+assert event.resource_id == expired_share.id
+assert event.resource_type == "consent_share"
+```
+
+- [ ] **Step 2: Run tests to verify current failures**
+
+Run: `python -m pytest -q backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_expired_share_cleanup.py`
+Expected: FAIL due to async/sync mismatch, invalid factory args, and invalid `AuditEvent.share_id` usage
+
+- [ ] **Step 3: Write minimal implementation (replace with harness-valid tests)**
+
+```python
+# backend/tests/test_verified_clinician.py (core test)
+from tests.support.consent_api import auth_headers, login, seed_report, seed_user
+
+
+def test_share_with_non_clinician_role_is_rejected(consent_api):
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient@example.com", role="patient")
+        seed_user(session, email="other_patient@example.com", role="patient")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    token = login(consent_api, email="patient@example.com")
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(token),
+        json={
+            "clinician_email": "other_patient@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    )
+    assert response.status_code == 400
+```
+
+```python
+# backend/tests/test_expired_share_cleanup.py (replace invalid field usage)
+from sqlalchemy import select
+from app.db.models import AuditEvent
+
+
+event = session.scalar(
+    select(AuditEvent)
+    .where(AuditEvent.resource_type == "consent_share")
+    .where(AuditEvent.resource_id == expired_share.id)
+    .where(AuditEvent.action == "expired")
+)
+assert event is not None
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest -q backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_expired_share_cleanup.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_expired_share_cleanup.py
+git commit -m "test(consent): replace broken async fixture tests with valid integration coverage"
+```
+
+---
+
+### Task 8: Full Verification and Plan-Doc Sync
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-09-consent-sharing-stabilization-design.md` (only if behavior wording changed)
+- Test: targeted and relevant backend suites
+
+- [ ] **Step 1: Write a failing verification target list in PR notes**
+
+```text
+Expected green suites:
+- backend/tests/test_harness_imports.py
+- backend/tests/test_verified_clinician.py
+- backend/tests/test_audit_sharing.py
+- backend/tests/test_expiry_enforcement.py
+- backend/tests/test_clinician_endpoints.py
+- backend/tests/test_audit_log_retrieval.py
+- backend/tests/test_expired_share_cleanup.py
+```
+
+- [ ] **Step 2: Run all targeted tests**
+
+Run:
+`python -m pytest -q backend/tests/test_harness_imports.py backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_clinician_endpoints.py backend/tests/test_audit_log_retrieval.py backend/tests/test_expired_share_cleanup.py`
+
+Expected: PASS
+
+- [ ] **Step 3: Run a broader regression sweep for auth/report paths**
+
+Run:
+`python -m pytest -q backend/tests/test_auth_api.py backend/tests/test_clinician_endpoints.py backend/tests/test_audit_log_retrieval.py`
+
+Expected: PASS
+
+- [ ] **Step 4: Update design doc if any plan-to-implementation contract changed**
+
+```markdown
+# docs/superpowers/specs/2026-04-09-consent-sharing-stabilization-design.md
+- Keep canonical clinician path at /api/v1/reports/shared-reports.
+- Confirm test harness now uses shared consent_api fixture.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-09-consent-sharing-stabilization-design.md
+git commit -m "docs: sync stabilization spec with implemented test harness details"
+```
+
+---
+
+## Self-Review
+
+### 1) Spec Coverage Check
+- Audit scoping fix: Task 3
+- Cleanup taxonomy fix: Task 4
+- Endpoint contract alignment: Task 5
+- Test harness and failing test stabilization: Tasks 1, 2, 6, 7
+- Verification criteria: Task 8
+
+No spec gap found.
+
+### 2) Placeholder Scan
+- Verified: no `TODO`, `TBD`, `implement later`, or "similar to Task N" shortcuts.
+
+### 3) Type/Signature Consistency Check
+- Canonical route used consistently: `/api/v1/reports/shared-reports`
+- Audit schema uses `resource_type/resource_id/action` consistently.
+- Shared harness type name is consistent: `ConsentApiHarness`.
+
+No naming mismatch found.

--- a/docs/superpowers/plans/2026-04-10-fr9-consent-sharing-gap-closure.md
+++ b/docs/superpowers/plans/2026-04-10-fr9-consent-sharing-gap-closure.md
@@ -1,0 +1,555 @@
+# FR9 Consent Sharing Gap-Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining FR9 backend gaps by adding view audit events, completing patient-scope clinician listing behavior, and making startup migrations interpreter-consistent.
+
+**Architecture:** Keep current backend boundaries and add minimal targeted logic: report access dependency writes view audit records, reports service expands patient-scope listing into concrete report rows, and app startup migration invocation uses the active interpreter. Use existing consent integration harness for TDD-first API tests and keep audit taxonomy consistent (`consent_share`).
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy async ORM, pytest, Starlette TestClient, Alembic
+
+---
+
+## Scope Check
+
+This plan is a single subsystem closure for FR9 backend behavior and tests. No decomposition is required.
+
+## File Structure
+
+### Create
+- `backend/tests/test_view_audit.py`
+  - Integration tests for report-view audit behavior.
+- `backend/tests/test_startup_migrations.py`
+  - Unit tests for startup migration command construction and subprocess invocation.
+
+### Modify
+- `backend/app/dependencies/reports.py`
+  - Add view-event write on successful non-owner report access via active share.
+- `backend/app/services/reports.py`
+  - Expand patient-scope shares into report rows for clinician listing and dedupe by report.
+- `backend/app/main.py`
+  - Invoke alembic via active interpreter (`sys.executable -m alembic`).
+- `backend/tests/test_clinician_endpoints.py`
+  - Add patient-scope listing coverage and overlap-dedupe assertions.
+
+---
+
+### Task 1: Add Failing Tests for View Audit Events
+
+**Files:**
+- Create: `backend/tests/test_view_audit.py`
+- Test: `backend/tests/test_view_audit.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/test_view_audit.py
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import AuditEvent
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def test_non_owner_report_access_creates_view_audit_event(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-view@example.com", role="patient")
+        clinician = seed_user(session, email="clinician-view@example.com", role="clinician")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient-view@example.com")
+    share = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": "clinician-view@example.com",
+            "scope": "report",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert share.status_code == 201, share.text
+    share_id = share.json()["id"]
+
+    clinician_token = login(consent_api, email="clinician-view@example.com")
+    read = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(clinician_token),
+    )
+    assert read.status_code == 200, read.text
+
+    with consent_api.session_factory() as session:
+        event = session.scalar(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.resource_id == share_id)
+            .where(AuditEvent.action == "view")
+        )
+
+    assert event is not None
+    assert event.actor_user_id is not None
+    assert event.subject_user_id is not None
+
+
+def test_owner_report_access_does_not_create_view_audit_event(consent_api: ConsentApiHarness) -> None:
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email="patient-owner-view@example.com", role="patient")
+        report = seed_report(session, subject_email=patient.email, created_by_email=patient.email)
+
+    patient_token = login(consent_api, email="patient-owner-view@example.com")
+    read = consent_api.client.get(
+        f"/api/v1/reports/{report.id}",
+        headers=auth_headers(patient_token),
+    )
+    assert read.status_code == 200, read.text
+
+    with consent_api.session_factory() as session:
+        count = session.scalar(
+            select(AuditEvent)
+            .where(AuditEvent.resource_type == "consent_share")
+            .where(AuditEvent.action == "view")
+            .where((AuditEvent.context["report_id"]).as_string() == report.id)
+            .with_only_columns(select(AuditEvent).where(AuditEvent.resource_type == "consent_share").where(AuditEvent.action == "view").where((AuditEvent.context["report_id"]).as_string() == report.id).subquery().c.id)
+        )
+
+    assert count is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest -q backend/tests/test_view_audit.py`
+Expected: FAIL because no `view` audit event is currently emitted.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add backend/tests/test_view_audit.py
+git commit -m "test(audit): add failing coverage for report view events"
+```
+
+---
+
+### Task 2: Implement View Audit Event on Shared Access
+
+**Files:**
+- Modify: `backend/app/dependencies/reports.py`
+- Modify: `backend/tests/test_view_audit.py`
+- Test: `backend/tests/test_view_audit.py`
+
+- [ ] **Step 1: Write minimal implementation**
+
+```python
+# backend/app/dependencies/reports.py (inside get_accessible_report)
+if share is not None:
+    audit = AuditEvent(
+        actor_user_id=auth.user.id,
+        subject_user_id=auth.user.id,
+        resource_type="consent_share",
+        resource_id=share.id,
+        action="view",
+        context={
+            "report_id": report.id,
+            "scope": share.scope.value,
+            "access_level": share.access_level.value,
+        },
+        occurred_at=now,
+    )
+    session.add(audit)
+    await session.commit()
+    return report
+```
+
+- [ ] **Step 2: Simplify owner-no-view assertion to robust query**
+
+```python
+# backend/tests/test_view_audit.py (owner test section)
+with consent_api.session_factory() as session:
+    rows = session.scalars(
+        select(AuditEvent)
+        .where(AuditEvent.resource_type == "consent_share")
+        .where(AuditEvent.action == "view")
+    ).all()
+
+assert all((row.context or {}).get("report_id") != report.id for row in rows)
+```
+
+- [ ] **Step 3: Run tests to verify pass**
+
+Run: `python -m pytest -q backend/tests/test_view_audit.py`
+Expected: PASS.
+
+- [ ] **Step 4: Run targeted regression checks**
+
+Run: `python -m pytest -q backend/tests/test_expiry_enforcement.py backend/tests/test_audit_log_retrieval.py`
+Expected: PASS.
+
+- [ ] **Step 5: Commit implementation**
+
+```bash
+git add backend/app/dependencies/reports.py backend/tests/test_view_audit.py
+git commit -m "feat(audit): emit view events for shared report access"
+```
+
+---
+
+### Task 3: Add Failing Tests for Patient-Scope Listing Expansion
+
+**Files:**
+- Modify: `backend/tests/test_clinician_endpoints.py`
+- Test: `backend/tests/test_clinician_endpoints.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_clinician_endpoints.py (add tests)
+def test_patient_scope_share_lists_all_patient_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-scope-list@example.com"
+    clinician_email = "clinician-scope-list@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(session, subject_email=patient_email, created_by_email=patient_email)
+        report_b = seed_report(session, subject_email=patient_email, created_by_email=patient_email)
+
+    patient_token = login(consent_api, email=patient_email)
+    share = consent_api.client.post(
+        f"/api/v1/reports/{report_a.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "patient",
+            "access_level": "read",
+            "expires_at": (datetime.now(UTC) + timedelta(days=7)).isoformat(),
+        },
+    )
+    assert share.status_code == 201, share.text
+
+    clinician_token = login(consent_api, email=clinician_email)
+    response = consent_api.client.get(
+        "/api/v1/reports/shared-reports",
+        headers=auth_headers(clinician_token),
+    )
+    assert response.status_code == 200, response.text
+
+    ids = {item["report"]["id"] for item in response.json()}
+    assert ids == {report_a.id, report_b.id}
+
+
+def test_overlap_patient_and_report_scope_is_deduped_by_report(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-overlap@example.com"
+    clinician_email = "clinician-overlap@example.com"
+
+    with consent_api.session_factory() as session:
+        seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(session, subject_email=patient_email, created_by_email=patient_email)
+
+    patient_token = login(consent_api, email=patient_email)
+    for scope in ("patient", "report"):
+        r = consent_api.client.post(
+            f"/api/v1/reports/{report.id}/share",
+            headers=auth_headers(patient_token),
+            json={
+                "clinician_email": clinician_email,
+                "scope": scope,
+                "access_level": "read",
+                "expires_at": (datetime.now(UTC) + timedelta(days=7)).isoformat(),
+            },
+        )
+        assert r.status_code == 201, r.text
+
+    clinician_token = login(consent_api, email=clinician_email)
+    response = consent_api.client.get(
+        "/api/v1/reports/shared-reports",
+        headers=auth_headers(clinician_token),
+    )
+    assert response.status_code == 200, response.text
+
+    ids = [item["report"]["id"] for item in response.json()]
+    assert ids.count(report.id) == 1
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py -k "patient_scope_share_lists_all_patient_reports or overlap_patient_and_report_scope_is_deduped_by_report"`
+Expected: FAIL because patient-scope rows are currently skipped.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add backend/tests/test_clinician_endpoints.py
+git commit -m "test(reports): add failing patient-scope shared listing coverage"
+```
+
+---
+
+### Task 4: Implement Patient-Scope Expansion and Dedupe in Listing Service
+
+**Files:**
+- Modify: `backend/app/services/reports.py`
+- Modify: `backend/tests/test_clinician_endpoints.py`
+- Test: `backend/tests/test_clinician_endpoints.py`
+
+- [ ] **Step 1: Implement expansion and dedupe logic**
+
+```python
+# backend/app/services/reports.py (replace get_clinician_shared_reports body)
+async def get_clinician_shared_reports(
+    session: AsyncSession,
+    *,
+    clinician_user_id: str,
+) -> list[ClinicianSharedReportItem]:
+    now = datetime.now(UTC)
+
+    share_rows = await session.execute(
+        select(ConsentShare, User)
+        .join(User, ConsentShare.subject_user_id == User.id)
+        .where(
+            ConsentShare.grantee_user_id == clinician_user_id,
+            ConsentShare.revoked_at.is_(None),
+            ConsentShare.expires_at > now,
+        )
+        .order_by(ConsentShare.created_at.desc())
+    )
+
+    by_report: dict[str, ClinicianSharedReportItem] = {}
+
+    for share, patient in share_rows.unique():
+        if share.scope == ConsentScope.REPORT and share.report_id is not None:
+            report = await session.scalar(
+                select(Report)
+                .where(Report.id == share.report_id)
+                .options(selectinload(Report.findings))
+            )
+            if report is None:
+                continue
+            by_report[report.id] = ClinicianSharedReportItem(
+                share_id=share.id,
+                report_id=report.id,
+                report=report,
+                patient=patient,
+                scope=share.scope.value,
+                access_level=share.access_level.value,
+                shared_at=share.created_at,
+                expires_at=share.expires_at,
+            )
+            continue
+
+        if share.scope == ConsentScope.PATIENT and share.report_id is None:
+            reports = (
+                await session.scalars(
+                    select(Report)
+                    .where(Report.subject_user_id == share.subject_user_id)
+                    .options(selectinload(Report.findings))
+                )
+            ).all()
+            for report in reports:
+                if report.id in by_report:
+                    continue
+                by_report[report.id] = ClinicianSharedReportItem(
+                    share_id=share.id,
+                    report_id=report.id,
+                    report=report,
+                    patient=patient,
+                    scope=share.scope.value,
+                    access_level=share.access_level.value,
+                    shared_at=share.created_at,
+                    expires_at=share.expires_at,
+                )
+
+    return sorted(by_report.values(), key=lambda item: item.shared_at, reverse=True)
+```
+
+- [ ] **Step 2: Run focused listing tests**
+
+Run: `python -m pytest -q backend/tests/test_clinician_endpoints.py`
+Expected: PASS.
+
+- [ ] **Step 3: Run impacted audit/list regression**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py backend/tests/test_verified_clinician.py`
+Expected: PASS.
+
+- [ ] **Step 4: Commit implementation**
+
+```bash
+git add backend/app/services/reports.py backend/tests/test_clinician_endpoints.py
+git commit -m "feat(reports): include patient-scope shares in clinician listing"
+```
+
+---
+
+### Task 5: Add Failing Tests for Startup Migration Invocation Robustness
+
+**Files:**
+- Create: `backend/tests/test_startup_migrations.py`
+- Test: `backend/tests/test_startup_migrations.py`
+
+- [ ] **Step 1: Write failing unit tests**
+
+```python
+# backend/tests/test_startup_migrations.py
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import main as main_mod
+
+
+@pytest.mark.asyncio
+async def test_run_alembic_migrations_uses_active_interpreter(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_process = SimpleNamespace(
+        communicate=AsyncMock(return_value=(b"ok", b"")),
+        returncode=0,
+    )
+
+    called_args = {}
+
+    async def fake_exec(*args, **kwargs):
+        called_args["args"] = args
+        called_args["kwargs"] = kwargs
+        return fake_process
+
+    monkeypatch.setattr(main_mod.asyncio, "create_subprocess_exec", fake_exec)
+
+    await main_mod._run_alembic_migrations(".", timeout=60)
+
+    assert called_args["args"][0] == sys.executable
+    assert called_args["args"][1:4] == ("-m", "alembic", "upgrade")
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `python -m pytest -q backend/tests/test_startup_migrations.py`
+Expected: FAIL because current command starts with plain `alembic`.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add backend/tests/test_startup_migrations.py
+git commit -m "test(startup): add failing migration invocation interpreter checks"
+```
+
+---
+
+### Task 6: Implement Interpreter-Based Migration Invocation
+
+**Files:**
+- Modify: `backend/app/main.py`
+- Modify: `backend/tests/test_startup_migrations.py`
+- Test: `backend/tests/test_startup_migrations.py`
+
+- [ ] **Step 1: Implement startup command change**
+
+```python
+# backend/app/main.py (imports)
+import sys
+```
+
+```python
+# backend/app/main.py (_run_alembic_migrations)
+process = await asyncio.create_subprocess_exec(
+    sys.executable,
+    "-m",
+    "alembic",
+    "upgrade",
+    "head",
+    cwd=project_root,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE,
+)
+```
+
+- [ ] **Step 2: Run migration invocation tests**
+
+Run: `python -m pytest -q backend/tests/test_startup_migrations.py`
+Expected: PASS.
+
+- [ ] **Step 3: Run end-to-end FR9 regression subset**
+
+Run: `python -m pytest -q backend/tests/test_view_audit.py backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_clinician_endpoints.py backend/tests/test_audit_log_retrieval.py backend/tests/test_expired_share_cleanup.py`
+Expected: PASS.
+
+- [ ] **Step 4: Commit implementation**
+
+```bash
+git add backend/app/main.py backend/tests/test_startup_migrations.py
+git commit -m "fix(startup): run alembic with active interpreter"
+```
+
+---
+
+### Task 7: Final FR9 Verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-10-fr9-consent-sharing-gap-closure-design.md` (only if behavior changed)
+- Test: FR9 suites
+
+- [ ] **Step 1: Run full FR9 backend verification**
+
+Run:
+`python -m pytest -q backend/tests/test_view_audit.py backend/tests/test_verified_clinician.py backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_clinician_endpoints.py backend/tests/test_audit_log_retrieval.py backend/tests/test_expired_share_cleanup.py backend/tests/test_startup_migrations.py`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader auth/report regression**
+
+Run:
+`python -m pytest -q backend/tests/test_auth_api.py backend/tests/test_clinician_endpoints.py backend/tests/test_audit_log_retrieval.py`
+
+Expected: PASS (skips acceptable where already expected by suite).
+
+- [ ] **Step 3: Sync spec only if contract changed**
+
+```markdown
+# docs/superpowers/specs/2026-04-10-fr9-consent-sharing-gap-closure-design.md
+- Confirmed `view` event semantics are non-owner report access only.
+- Confirmed patient-scope listing expansion and dedupe precedence.
+- Confirmed startup alembic invocation uses active interpreter.
+```
+
+- [ ] **Step 4: Commit spec sync if edited**
+
+```bash
+git add docs/superpowers/specs/2026-04-10-fr9-consent-sharing-gap-closure-design.md
+git commit -m "docs: sync FR9 gap-closure spec with implementation details"
+```
+
+---
+
+## Self-Review
+
+### 1) Spec Coverage
+- View audit event gap: Tasks 1-2
+- Patient-scope clinician listing gap: Tasks 3-4
+- Migration invocation reliability gap: Tasks 5-6
+- FR9 verification and DoD proof: Task 7
+
+No coverage gap found.
+
+### 2) Placeholder Scan
+- No placeholders (`TBD`, `TODO`, or undefined implementation steps) found.
+
+### 3) Type/Signature Consistency
+- Uses existing consent harness (`ConsentApiHarness`, `seed_user`, `seed_report`, `login`, `auth_headers`) consistently.
+- Keeps audit taxonomy as `resource_type = consent_share` across all new tests and implementation.
+- Keeps endpoint path consistent: `/api/v1/reports/shared-reports`.

--- a/docs/superpowers/plans/2026-04-10-fr9-consent-sharing-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-10-fr9-consent-sharing-review-fixes.md
@@ -1,0 +1,261 @@
+# FR9 Consent Sharing Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix report-audit cross-report leakage and tighten default expiry cleanup cadence while preserving existing FR9 contracts.
+
+**Architecture:** Apply minimal, localized changes: add failing tests for report-scoped audit isolation, update audit retrieval filters in the reports service to enforce report relevance, and reduce the scheduler default interval with env override unchanged. Keep role-based clinician validation and existing API payloads/messages unchanged.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy async ORM, pytest, Starlette TestClient
+
+---
+
+## Scope Check
+
+This work is a single backend subsystem fix and does not require decomposition.
+
+## File Structure
+
+### Modify
+- `backend/tests/test_audit_log_retrieval.py`
+  - Add failing case for patient-scope share view events leaking into another report's audit endpoint.
+- `backend/app/services/reports.py`
+  - Enforce event-level report relevance in `get_report_audit_log`.
+- `backend/tests/test_startup_migrations.py`
+  - Add scheduler default interval assertion for 5-minute default.
+- `backend/app/main.py`
+  - Change default `CLEANUP_INTERVAL_MINUTES` from 60 to 5.
+
+---
+
+### Task 1: Add Failing Audit Isolation Test
+
+**Files:**
+- Modify: `backend/tests/test_audit_log_retrieval.py`
+- Test: `backend/tests/test_audit_log_retrieval.py::test_patient_scope_view_events_do_not_leak_across_reports`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_patient_scope_view_events_do_not_leak_across_reports(consent_api: ConsentApiHarness) -> None:
+    patient_email = "patient-view-leak@example.com"
+    clinician_email = "clinician-view-leak@example.com"
+
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report_a = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+        report_b = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    share = consent_api.client.post(
+        f"/api/v1/reports/{report_a.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "patient",
+            "access_level": "read",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert share.status_code == 201, share.text
+
+    clinician_token = login(consent_api, email=clinician_email)
+    access_other_report = consent_api.client.get(
+        f"/api/v1/reports/{report_b.id}",
+        headers=auth_headers(clinician_token),
+    )
+    assert access_other_report.status_code == 200, access_other_report.text
+
+    response = _get_audit_log(
+        consent_api,
+        patient_token=patient_token,
+        report_id=report_a.id,
+    )
+    assert response.status_code == 200, response.text
+
+    leaked_rows = [
+        row
+        for row in response.json()
+        if row["action"] == "view" and row["context"].get("report_id") == report_b.id
+    ]
+    assert leaked_rows == []
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py -k patient_scope_view_events_do_not_leak_across_reports`
+Expected: FAIL due leaked view event on wrong report endpoint.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add backend/tests/test_audit_log_retrieval.py
+git commit -m "test(audit): add failing patient-scope view isolation coverage"
+```
+
+---
+
+### Task 2: Implement Report-Relevance Filtering in Audit Retrieval
+
+**Files:**
+- Modify: `backend/app/services/reports.py`
+- Test: `backend/tests/test_audit_log_retrieval.py::test_patient_scope_view_events_do_not_leak_across_reports`
+
+- [ ] **Step 1: Implement minimal filter update**
+
+```python
+# backend/app/services/reports.py (inside get_report_audit_log)
+from sqlalchemy import and_, or_, select
+
+report_id_in_context = (AuditEvent.context["report_id"]).as_string()
+
+query = select(AuditEvent).where(
+    AuditEvent.resource_type == "consent_share",
+    AuditEvent.resource_id.in_(share_ids),
+    or_(
+        report_id_in_context.is_(None),
+        report_id_in_context == report_id,
+    ),
+)
+```
+
+- [ ] **Step 2: Run targeted audit retrieval tests**
+
+Run: `python -m pytest -q backend/tests/test_audit_log_retrieval.py`
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+```bash
+git add backend/app/services/reports.py backend/tests/test_audit_log_retrieval.py
+git commit -m "fix(audit): scope report audit events to requested report"
+```
+
+---
+
+### Task 3: Add Failing Test for Cleanup Default Cadence
+
+**Files:**
+- Modify: `backend/tests/test_startup_migrations.py`
+- Test: `backend/tests/test_startup_migrations.py::test_app_lifespan_defaults_cleanup_interval_to_five_minutes`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_app_lifespan_defaults_cleanup_interval_to_five_minutes(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, int] = {}
+
+    class FakeScheduler:
+        def add_job(self, _func, _trigger, *, minutes: int, **_kwargs):
+            captured["minutes"] = minutes
+
+        def start(self):
+            return None
+
+        def shutdown(self):
+            return None
+
+    monkeypatch.delenv("CLEANUP_INTERVAL_MINUTES", raising=False)
+    monkeypatch.setattr(main_mod, "AsyncIOScheduler", lambda: FakeScheduler())
+    monkeypatch.setattr(main_mod, "_run_alembic_migrations", pytest.AsyncMock(return_value=None))
+
+    app = main_mod.create_app()
+    async with main_mod.app_lifespan(app):
+        pass
+
+    assert captured["minutes"] == 5
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `python -m pytest -q backend/tests/test_startup_migrations.py -k defaults_cleanup_interval_to_five_minutes`
+Expected: FAIL with current default 60.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add backend/tests/test_startup_migrations.py
+git commit -m "test(startup): add failing cleanup interval default coverage"
+```
+
+---
+
+### Task 4: Implement Cleanup Default Interval Change
+
+**Files:**
+- Modify: `backend/app/main.py`
+- Modify: `backend/tests/test_startup_migrations.py`
+- Test: `backend/tests/test_startup_migrations.py`
+
+- [ ] **Step 1: Update default cleanup interval**
+
+```python
+# backend/app/main.py
+cleanup_interval = int(os.getenv('CLEANUP_INTERVAL_MINUTES', '5'))
+```
+
+- [ ] **Step 2: Run startup tests**
+
+Run: `python -m pytest -q backend/tests/test_startup_migrations.py`
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+```bash
+git add backend/app/main.py backend/tests/test_startup_migrations.py
+git commit -m "fix(startup): set cleanup scheduler default to five minutes"
+```
+
+---
+
+### Task 5: Regression Verification
+
+**Files:**
+- Test: `backend/tests/test_audit_sharing.py`
+- Test: `backend/tests/test_expiry_enforcement.py`
+- Test: `backend/tests/test_expired_share_cleanup.py`
+- Test: `backend/tests/test_startup_migrations.py`
+- Test: `backend/tests/test_audit_log_retrieval.py`
+
+- [ ] **Step 1: Run full targeted regression set**
+
+Run: `python -m pytest -q backend/tests/test_audit_sharing.py backend/tests/test_expiry_enforcement.py backend/tests/test_expired_share_cleanup.py backend/tests/test_startup_migrations.py backend/tests/test_audit_log_retrieval.py`
+Expected: PASS.
+
+- [ ] **Step 2: Commit if any regression test stabilization edits were required**
+
+```bash
+git add <any-updated-test-files>
+git commit -m "test: stabilize FR9 review-fix regression coverage"
+```
+
+(If no edits were required after regression run, skip this commit.)
+
+---
+
+## Self-Review
+
+### 1) Spec coverage
+- Report audit isolation fixed: Tasks 1-2
+- Cleanup default cadence tightened: Tasks 3-4
+- Regression validation retained: Task 5
+- Role-only clinician decision preserved: no `is_verified` change in tasks
+
+No coverage gaps found.
+
+### 2) Placeholder scan
+- No placeholder markers (`TBD`, `TODO`, `implement later`) in tasks.
+
+### 3) Type/signature consistency
+- Uses existing `get_report_audit_log` function and existing startup lifespan wiring.
+- Uses existing test harness modules and naming conventions.

--- a/docs/superpowers/specs/2026-04-09-consent-sharing-stabilization-design.md
+++ b/docs/superpowers/specs/2026-04-09-consent-sharing-stabilization-design.md
@@ -1,0 +1,183 @@
+# Consent Sharing Stabilization Design (Post-Review Fix Plan)
+
+Date: 2026-04-09
+Branch: backend/consent-sharing
+Status: Proposed
+
+## 1. Context
+
+Branch review identified blocking issues in consent-sharing backend and tests:
+
+- Audit log retrieval is not scoped to the requested report.
+- Expiry cleanup writes audit events with inconsistent `resource_type`.
+- Clinician shared-report endpoint path differs between implementation and tests.
+- New tests are incompatible with current synchronous test harness/factory APIs.
+- Some tests reference non-existent `AuditEvent.share_id`.
+
+This design defines a focused stabilization pass to make behavior correct, testable, and consistent with current backend conventions.
+
+## 2. Goals
+
+- Ensure audit log endpoint returns only events relevant to the requested report.
+- Standardize audit event taxonomy for consent share lifecycle events.
+- Align API path contract and tests for clinician shared report listing.
+- Make new consent-sharing tests executable under current backend test architecture.
+- Remove invalid model field usage from tests and assert against real schema.
+
+## 3. Non-Goals
+
+- No redesign of auth/token flows.
+- No frontend UX redesign.
+- No broader persistence schema migration beyond what is needed to stabilize behavior.
+- No refactor of unrelated parser/interpret/translate modules.
+
+## 4. Approaches Considered
+
+## Approach A (Recommended): Minimal Surface Stabilization
+
+- Keep canonical clinician listing path as `/api/v1/reports/shared-reports`.
+- Fix service/query logic and normalize audit `resource_type` to `consent_share`.
+- Rewrite failing consent-sharing tests to match current sync fixture/factory contracts.
+- Add focused tests for report-scoped audit retrieval and cleanup audit consistency.
+
+Trade-offs:
+- Fastest and lowest-risk path.
+- Preserves existing router organization (`reports` router owns report-sharing concerns).
+- Does not offer temporary backward-compatibility alias for `/clinician/shared-reports`.
+
+## Approach B: Dual Endpoint Compatibility During Transition
+
+- Same as Approach A, plus add temporary alias endpoint `/api/v1/clinician/shared-reports` that delegates to report router logic.
+
+Trade-offs:
+- Reduces client break risk if external clients already use old path.
+- Increases maintenance overhead and deprecation management.
+- Not necessary if no external dependency exists yet.
+
+## Approach C: Broader Domain Re-segmentation
+
+- Introduce dedicated `consent` module/router/service boundaries and migrate all sharing/audit logic to it.
+
+Trade-offs:
+- Best long-term separation of concerns.
+- Too large for current stabilization ask; higher regression risk and delivery delay.
+
+## Recommendation
+
+Choose Approach A.
+
+Reasoning: The branch needs correctness and test reliability fixes first. Approach A resolves all identified blockers with the smallest behavioral surface area and lowest merge risk.
+
+## 5. Design Decisions
+
+### 5.1 API Contract Decision
+
+Canonical clinician shared-report endpoint will be:
+
+- `GET /api/v1/reports/shared-reports`
+
+All tests and docs will align to this path.
+
+### 5.2 Audit Event Taxonomy
+
+All consent sharing lifecycle events will use:
+
+- `resource_type = "consent_share"`
+
+Actions:
+
+- `created`
+- `revoked`
+- `expired`
+
+This unifies lookup behavior across access checks, audit retrieval, and cleanup jobs.
+
+### 5.3 Report-Scoped Audit Retrieval
+
+`get_report_audit_log(report_id, owner_user_id, actions)` will be constrained to consent shares that apply to that report:
+
+- Include report-scoped share events where `ConsentShare.scope = report` and `ConsentShare.report_id = report_id`.
+- Include patient-scoped share events where `ConsentShare.scope = patient` and `ConsentShare.report_id IS NULL` only if they grant access to the same report owner (subject user).
+
+Return ordering remains descending by `occurred_at`.
+
+### 5.4 Test Architecture Alignment
+
+Given current backend tests use synchronous SQLAlchemy `Session` and sync factory methods:
+
+- Convert new consent-sharing tests to sync style (no `async def`, no `await` on sync factories).
+- Use factory parameter names that exist today (`subject`, `created_by`, `grantee`).
+- Remove `AsyncSession` fixture annotations in these tests.
+- Replace `AuditEvent.share_id` assertions with `AuditEvent.resource_id` + `resource_type` filters.
+
+### 5.5 Import Stability in Test Harness
+
+To avoid import collisions for `tests.factories` during pytest invocation:
+
+- Ensure local tests package import is unambiguous (prefer explicit package import strategy compatible with current project layout).
+- Add targeted regression check in test run instructions to verify pytest discovers local factories correctly.
+
+## 6. Implementation Outline
+
+1. Service Fixes
+- Update `get_report_audit_log` query predicates for true report scoping.
+- Update `cleanup_expired_shares` to write `resource_type="consent_share"`.
+
+2. Contract Alignment
+- Confirm clinician shared-report route remains under reports router.
+- Update tests and docs that currently target `/api/v1/clinician/shared-reports`.
+
+3. Test Suite Stabilization
+- Refactor new consent-sharing tests to sync style and valid factory args.
+- Replace invalid model-field assertions and align expectations with real schema.
+
+4. Verification
+- Run targeted consent-sharing test subset.
+- Run broader backend tests relevant to reports/auth/audit to catch regressions.
+
+## 7. Error Handling and Edge Cases
+
+- Expired shares must deny access with clear 403 detail and write at most one expiry audit event per share for lazy-access path.
+- Cleanup job should remain idempotent for already-revoked shares.
+- Audit retrieval should return 403 for non-owner and 404 for non-existent report.
+- Action filter must only include valid events for the report scope.
+
+## 8. Testing Strategy
+
+Required automated coverage:
+
+- Unit/service tests:
+  - `get_report_audit_log` returns only report-relevant events.
+  - `cleanup_expired_shares` writes `consent_share` events.
+  - Expiry access path dedupe behavior remains correct.
+
+- API tests:
+  - `GET /api/v1/reports/shared-reports` returns expected rows and excludes revoked/expired.
+  - `GET /api/v1/audit/reports/{report_id}` enforces owner-only access and action filters.
+
+- Harness checks:
+  - pytest import/discovery works from documented working directory and PYTHONPATH setup.
+
+## 9. Acceptance Criteria for This Stabilization
+
+- No new consent-sharing test fails due to fixture style mismatch, invalid factory args, or invalid model fields.
+- Audit log endpoint is demonstrably report-scoped with tests proving exclusion of unrelated report events.
+- Cleanup and access-path audit events use identical resource taxonomy (`consent_share`).
+- Clinician shared-report path contract is consistent across implementation, tests, and docs.
+
+## 10. Risks and Mitigations
+
+- Risk: Over-tight audit filtering could hide expected patient-scope events.
+  - Mitigation: Add explicit tests for both report-scope and patient-scope shares affecting the target report.
+
+- Risk: Endpoint path change assumptions may break external consumers.
+  - Mitigation: Keep canonical reports router path and document clearly; add alias only if stakeholder confirms external dependency.
+
+- Risk: Test refactor masks async behavior assumptions.
+  - Mitigation: Keep service-level behavior assertions strong and deterministic with current sync fixture model.
+
+## 11. Rollout
+
+- Single PR update on current branch.
+- Merge only after targeted and relevant backend tests pass.
+- Include concise release note in PR summary: "Consent-sharing stabilization (audit scoping, taxonomy consistency, contract/test alignment)."

--- a/docs/superpowers/specs/2026-04-10-fr9-consent-sharing-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-04-10-fr9-consent-sharing-gap-closure-design.md
@@ -1,0 +1,182 @@
+# FR9 Consent Sharing Gap-Closure Design
+
+Date: 2026-04-10
+Branch: backend/consent-sharing
+Status: Proposed
+
+## 1. Purpose
+
+This design closes remaining FR9 behavior gaps after the consent-sharing stabilization pass.
+
+Target FR9 outcomes:
+- Patients create scoped, expiring shares by specifying clinician, scope, and expiry.
+- Revocation and expiry immediately remove access.
+- Share, view, revoke, and expiry actions generate timestamped audit events.
+- Post-revocation and post-expiry access is denied with clear messages.
+- Authenticated clinicians can list actively shared reports with full report details and patient profile details, respecting active share scope.
+
+## 2. Current Gaps
+
+1. View audit events are missing for shared-report access.
+2. Clinician shared-report listing excludes patient-scope shares (`scope=patient`) with no direct `report_id` link.
+3. Startup migration execution uses shell-level `alembic`, which can resolve outside the active Python environment.
+
+## 3. Scope and Non-Goals
+
+In scope:
+- Backend behavior and tests for view auditing.
+- Backend behavior and tests for patient-scope expansion in clinician listing.
+- Backend startup migration invocation reliability.
+
+Out of scope:
+- UI changes.
+- Schema redesign beyond additive, minimal migration-safe adjustments.
+- Non-FR9 features.
+
+## 4. Approaches Considered
+
+## Approach A (Recommended): Targeted FR9 Gap Closure
+
+- Add report view audit creation when a non-owner accesses a report through active share.
+- Expand clinician shared-reports service to include all reports for active patient-scope shares.
+- Run alembic via the active interpreter (`python -m alembic`) to remove PATH coupling.
+- Add targeted service/API tests for new view-audit and patient-scope listing behavior.
+
+Trade-offs:
+- Minimal change surface.
+- Preserves current architecture and contracts.
+- Requires careful duplicate handling when patient- and report-scope shares coexist.
+
+## Approach B: Domain Module Refactor First
+
+- Move consent and audit orchestration into a dedicated consent domain package, then implement gap fixes.
+
+Trade-offs:
+- Cleaner long-term boundaries.
+- Higher risk and scope for current FR9 closure.
+- Slower delivery.
+
+## Approach C: Event-Layer Abstraction First
+
+- Introduce centralized audit event publisher with event enums before any behavior fixes.
+
+Trade-offs:
+- Better consistency and future extensibility.
+- Extra abstraction overhead now.
+- Not required to satisfy FR9 immediately.
+
+## Recommendation
+
+Choose Approach A.
+
+Reasoning: It directly satisfies FR9 gaps with low risk and minimal architecture churn.
+
+## 5. Design Decisions
+
+### 5.1 View Event Definition
+
+A `view` audit event is created when an authenticated non-owner successfully accesses a report via an active share (report-scope or patient-scope).
+
+Not included as `view` events:
+- Owner viewing own report.
+- Listing shared reports endpoint calls.
+
+Audit record shape:
+- `resource_type = "consent_share"`
+- `action = "view"`
+- `resource_id = <matching active share id>`
+- `actor_user_id = clinician user id`
+- `subject_user_id = clinician user id`
+- `occurred_at = current UTC`
+- context includes at least: `report_id`, `scope`, `access_level`
+
+### 5.2 Patient-Scope Listing Expansion
+
+For an active patient-scope share (`scope=patient`, `report_id IS NULL`), clinician shared-reports listing returns all currently active reports owned by that patient.
+
+Behavior details:
+- Each returned row still includes report details + patient profile.
+- Dedupe by `report_id` when both patient-scope and report-scope shares grant access.
+- Precedence rule for duplicate grants:
+  - If both scopes exist for same report, prefer report-scope share metadata for that report row.
+
+### 5.3 Migration Invocation Reliability
+
+Startup migration process in app lifespan must use the active Python interpreter to avoid external PATH dependency.
+
+Decision:
+- Replace shell command `alembic upgrade head` with `python -m alembic upgrade head` (using `sys.executable`).
+
+### 5.4 Error and Access Semantics
+
+Retain existing clear denial messages:
+- Revoked: `Access has been revoked`
+- Expired: `Share has expired`
+- Non-clinician listing shared reports: `Only clinicians may view shared reports`
+
+### 5.5 Test-First Strategy
+
+All new behavior changes require tests written first and failing first:
+- View-event creation on shared access.
+- No view-event creation for owner access.
+- Patient-scope listing includes all active patient reports.
+- Dedupe and precedence behavior when report- and patient-scope shares overlap.
+- Startup migration invocation uses interpreter-based alembic call (unit-level invocation test/mocked subprocess assertion).
+
+## 6. Architecture and Data Flow
+
+### 6.1 Shared Report Access Path
+
+1. Request hits report retrieval dependency.
+2. Access grant is evaluated (owner, active share, revoked, expired).
+3. If non-owner share access succeeds:
+   - create `view` audit event.
+   - return report payload.
+4. If revoked/expired, deny with existing clear message.
+
+### 6.2 Clinician Listing Path
+
+1. Validate authenticated user role includes clinician.
+2. Query active shares for clinician.
+3. For report-scope shares: include linked report directly.
+4. For patient-scope shares: query active reports for subject patient and include each report.
+5. Dedupe by report id with precedence rule.
+6. Return report + patient profile rows.
+
+## 7. Testing Plan
+
+Required tests:
+- API/integration
+  - shared access creates `view` audit event.
+  - owner access does not create `view` event.
+  - revoked/expired denial remains unchanged.
+  - clinician listing includes patient-scope reports.
+  - listing dedupes overlap and applies precedence.
+- Service-level
+  - clinician listing expansion logic for patient-scope shares.
+- startup behavior
+  - migration subprocess command built with active interpreter.
+
+Regression suites to run:
+- consent-sharing subset and audit subset.
+- auth/report/audit broader subset.
+
+## 8. Risks and Mitigations
+
+Risk: Excessive audit volume from view events.
+- Mitigation: start with per-successful-access events; monitor event volume and add optional throttling later if needed.
+
+Risk: Duplicate listing rows from overlapping shares.
+- Mitigation: deterministic dedupe by `report_id` with explicit precedence rule and tests.
+
+Risk: interpreter-based migration command behavior differences.
+- Mitigation: unit test command construction and run existing startup-related test paths.
+
+## 9. Definition of Done Mapping
+
+- Patients can create scoped, expiring shares: existing behavior retained and verified.
+- Revocation/expiry removes access immediately: existing behavior retained and verified.
+- Audit log receives timestamped events quickly and consistently: add `view` event path to complete event set.
+- Access after expiry/revocation denied clearly: retained.
+- Clinicians retrieve all actively shared reports including patient profile details under active scope: complete via patient-scope expansion.
+- Tests cover view/share/revoke/expiry: completed with new view and patient-scope tests.

--- a/docs/superpowers/specs/2026-04-10-fr9-consent-sharing-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-10-fr9-consent-sharing-review-fixes-design.md
@@ -1,0 +1,154 @@
+# FR9 Consent Sharing Review-Fix Design
+
+Date: 2026-04-10
+Branch: backend/consent-sharing
+Status: Proposed
+
+## 1. Purpose
+
+This design addresses the remaining issues found during branch review for FR9 consent sharing behavior and coding conventions.
+
+Goals for this fix cycle:
+- Eliminate report-audit cross-report leakage for report-specific audit retrieval.
+- Improve automatic expiry cleanup timing defaults to better align with FR9 operational latency expectations.
+- Preserve existing API contracts and message semantics.
+- Keep clinician validation as role-based only (no `is_verified` gate) per product decision.
+
+## 2. Inputs and Constraints
+
+Source findings:
+- Report-specific audit retrieval can include unrelated events due to patient-scope share id reuse.
+- Default cleanup interval may be too coarse for FR9 timing intent.
+- Existing clinician sharing rule is role-only and remains intentional.
+
+Constraints:
+- Minimize change surface (Approach 1 selected).
+- No schema migration in this cycle.
+- No frontend changes.
+- No broad refactoring.
+
+## 3. Scope and Non-Goals
+
+In scope:
+- `backend/app/services/reports.py`
+  - Tighten report-audit filtering logic.
+- `backend/app/main.py`
+  - Reduce default `CLEANUP_INTERVAL_MINUTES` while preserving env override.
+- `backend/tests/test_audit_log_retrieval.py`
+  - Strengthen report-isolation assertions for audit events.
+- `backend/tests/test_expired_share_cleanup.py`
+  - Ensure cleanup behavior remains correct with updated default cadence assumptions.
+
+Out of scope:
+- Introducing `is_verified` clinician gate.
+- Audit schema redesign.
+- New endpoints or response model changes.
+- Unrelated cleanup/refactor work.
+
+## 4. Selected Approach
+
+Approach 1: Minimal surgical fixes.
+
+Why:
+- Directly resolves the blocking correctness issue.
+- Keeps blast radius small and low risk.
+- Preserves already stabilized FR9 behavior and contracts.
+
+## 5. Design Details
+
+### 5.1 Report-Scoped Audit Filtering
+
+Problem:
+- Filtering by consent share ids alone is insufficient when patient-scope shares can apply to multiple reports.
+
+Design:
+- Keep endpoint route unchanged (`/api/v1/audit/reports/{report_id}`).
+- In `get_report_audit_log`, enforce event-level report relevance:
+  - Include events where `context.report_id == requested_report_id`.
+  - Include report-scope events tied to requested report even if context is sparse.
+  - Exclude events whose context clearly targets other report ids.
+- Preserve existing action filter behavior (`action` query param).
+
+Result:
+- Report audit endpoint becomes truly report-scoped and deterministic.
+
+### 5.2 Expiry Cleanup Default Timing
+
+Problem:
+- Cleanup schedule default can delay automatic revocation/audit visibility compared to FR9 expectations.
+
+Design:
+- Update default cleanup interval constant in app lifespan scheduler setup from 60 minutes to 5 minutes.
+- Keep `CLEANUP_INTERVAL_MINUTES` env override unchanged.
+- Keep immediate deny-on-access behavior for expired/revoked shares unchanged.
+
+Result:
+- Better out-of-the-box timing without changing deployment-level configurability.
+
+### 5.3 Clinician Verification Rule (Explicitly Frozen)
+
+Decision:
+- Share recipient eligibility remains role-based (`clinician` role required).
+- `is_verified` is not enforced in this fix cycle.
+
+Rationale:
+- Product decision for this cycle is role-only sufficiency.
+- Avoid introducing policy changes unrelated to current blocking defect.
+
+## 6. Data Flow
+
+### 6.1 Report Audit Retrieval
+
+1. Validate report exists and requester owns it.
+2. Identify candidate consent shares relevant to the owner/report relationship.
+3. Query consent audit events for those shares.
+4. Apply report relevance rules at event level.
+5. Apply optional action filter.
+6. Return events ordered newest-first.
+
+### 6.2 Expiry Automation
+
+1. Scheduler triggers cleanup job at configured interval (shorter default).
+2. Cleanup marks active expired shares as revoked.
+3. Cleanup writes `expired` audit events.
+4. Access dependency continues immediate denial for expired/revoked shares regardless of scheduler timing.
+
+## 7. Error Handling and Compatibility
+
+- Keep existing HTTP status codes and detail messages for revoked/expired/forbidden paths.
+- Keep audit response schema unchanged.
+- Keep migration startup behavior unchanged beyond previously adopted interpreter-based invocation.
+
+## 8. Testing Strategy
+
+Primary tests:
+- `backend/tests/test_audit_log_retrieval.py`
+  - Verify report-specific endpoint excludes unrelated report events in overlap scenarios.
+  - Verify action filter still returns only requested actions.
+- `backend/tests/test_expired_share_cleanup.py`
+  - Verify revoked marking and `expired` audit emission still hold.
+  - Verify multi-expired cleanup behavior remains correct.
+
+Regression subset:
+- `backend/tests/test_audit_sharing.py`
+- `backend/tests/test_expiry_enforcement.py`
+- `backend/tests/test_startup_migrations.py`
+
+## 9. Risks and Mitigations
+
+Risk: Over-filtering removes valid audit rows.
+- Mitigation: Add overlap and mixed-scope tests that assert expected inclusion and exclusion explicitly.
+
+Risk: Shorter cleanup interval increases DB activity.
+- Mitigation: Keep env override and choose a moderate default; monitor post-deploy.
+
+Risk: Ambiguity between patient-wide and report-scoped audit semantics.
+- Mitigation: Keep endpoint explicitly report-scoped and encode this in tests.
+
+## 10. Definition of Done
+
+- Report-scoped audit retrieval no longer leaks unrelated report events.
+- Expiry cleanup default cadence is 5 minutes while remaining configurable.
+- Existing FR9 behavior for deny messages and audit taxonomy remains intact.
+- Targeted and regression tests pass.
+- No API contract changes.


### PR DESCRIPTION
# Summary
This PR completes the backend consent-sharing flow with enforceable access control, expiry handling, and auditability for FR9-style sharing requirements.
It also tightens startup/runtime behavior and adds a reusable integration-test harness so sharing behavior is verified end-to-end.

# Why
Before this branch:

- Share lifecycle behavior was only partially audited.
- Expiry/revocation handling had edge-case gaps across access paths.
- Clinician shared-report discovery needed stronger scope handling and dedupe behavior.
- Startup migrations and cleanup scheduling needed more reliable defaults/testing.

This made consent behavior harder to trust and harder to extend safely.

# What Changed
## Consent Sharing and Access
- Enforced clinician-role recipient validation for sharing.
- Added robust share create/revoke flows with scope-aware context.
- Added patient-scope and report-scope handling with deterministic precedence.

## Audit and Compliance
- Added audit events for share created, revoked, viewed, and expired.
- Added patient-facing audit log retrieval with ownership checks and action filtering.
- Scoped audit retrieval to relevant share/report context.

## Clinician Shared Reports
- Added clinician shared-report listing endpoint.
- Expanded patient-scope shares into report rows.
- Added deduplication/precedence behavior when scope grants overlap.

## Expiry Automation and Startup Reliability
- Added scheduled cleanup for expired shares (default 5 minutes, env-configurable).
- Standardized startup migrations via active interpreter invocation.

## Test Infrastructure and Coverage
- Added a reusable consent API integration harness.
- Added broad integration coverage for sharing, revocation, expiry enforcement, cleanup, audit retrieval/filtering, view events, and clinician listing.

# Functional Fixes
- Sharing mode now syncs to active consent state.
- Expired/revoked access is denied with clear behavior and audit consistency.
- Overlapping patient/report scope listing now dedupes predictably.
- Startup migration execution is environment-consistent.

# Verification
Ran targeted backend suites covering consent, audit, expiry, clinician endpoints, and startup migration behavior.
Result: all targeted tests passed.

# Impact
No intentional breaking API changes for existing consumers.
Primary impact is internal quality:

- clearer service-layer ownership of consent workflows
- stronger audit/compliance guarantees
- more reliable operational behavior
- better long-term maintainability

# Remaining Follow-Up
Next useful seam to improve is deeper query/performance optimization in shared-report and audit retrieval paths as data volume grows.
