### PR TITLE
feat(T6/T7): thread finding anchors, notifications, audit-log UI

### DIFF
--- a/backend/alembic/versions/20260418_02_thread_anchor_and_access.py
+++ b/backend/alembic/versions/20260418_02_thread_anchor_and_access.py
@@ -1,0 +1,40 @@
+"""Add finding anchor to conversation_threads for T7.
+
+Revision ID: 20260418_02
+Revises: 20260326_01
+Create Date: 2026-04-18 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260418_02"
+down_revision = "20260326_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("conversation_threads") as batch_op:
+        batch_op.add_column(
+            sa.Column("finding_id", sa.String(length=36), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_conversation_threads_finding_id_report_findings",
+            "report_findings",
+            ["finding_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("conversation_threads") as batch_op:
+        batch_op.drop_constraint(
+            "fk_conversation_threads_finding_id_report_findings",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("finding_id")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -390,6 +390,9 @@ class ConversationThread(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     subject_user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     created_by_user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
     report_id: Mapped[str | None] = mapped_column(ForeignKey("reports.id", ondelete="SET NULL"), nullable=True)
+    finding_id: Mapped[str | None] = mapped_column(
+        ForeignKey("report_findings.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str | None] = mapped_column(String(255), nullable=True)
     status: Mapped[ThreadStatus] = mapped_column(
         enum_column(ThreadStatus, name="thread_status"),
@@ -407,6 +410,7 @@ class ConversationThread(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         foreign_keys=[created_by_user_id],
     )
     report: Mapped[Report | None] = relationship(back_populates="threads")
+    finding: Mapped[ReportFinding | None] = relationship(foreign_keys=[finding_id])
     participants: Mapped[list[ThreadParticipant]] = relationship(
         back_populates="thread",
         cascade="all, delete-orphan",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from .routers.health import router as health_router
 from .routers.interpret import router as interpret_router
 from .routers.parse import router as parse_router
 from .routers.reports import router as reports_router
+from .routers.notifications import router as notifications_router
 from .routers.threads import router as threads_router
 from .routers.translate import router as translate_router
 from .services.reports import cleanup_expired_shares
@@ -216,6 +217,7 @@ def create_app() -> FastAPI:
     app.include_router(audit_router, prefix="/api/v1")
     app.include_router(reports_router, prefix="/api/v1")
     app.include_router(threads_router, prefix="/api/v1")
+    app.include_router(notifications_router, prefix="/api/v1")
     app.include_router(translate_router, prefix="/api/v1")
 
     @app.get("/", include_in_schema=False)

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Notification
+from app.db.session import get_db_session
+from app.dependencies.auth import AuthContext, get_current_auth_context
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+class NotificationOut(BaseModel):
+    id: str
+    kind: str
+    title: str
+    thread_id: str | None
+    report_id: str | None
+    payload: dict[str, Any]
+    read_at: datetime | None
+    created_at: datetime
+
+
+class UnreadCountOut(BaseModel):
+    unread: int
+
+
+@router.get("", response_model=list[NotificationOut])
+async def list_notifications(
+    unread_only: bool = False,
+    limit: int = 50,
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[NotificationOut]:
+    limit = max(1, min(limit, 200))
+    stmt = (
+        select(Notification)
+        .where(Notification.user_id == auth.user.id)
+        .order_by(Notification.created_at.desc())
+        .limit(limit)
+    )
+    if unread_only:
+        stmt = stmt.where(Notification.read_at.is_(None))
+
+    result = await session.scalars(stmt)
+    return [
+        NotificationOut(
+            id=n.id,
+            kind=n.kind.value,
+            title=n.title,
+            thread_id=n.thread_id,
+            report_id=n.report_id,
+            payload=n.payload or {},
+            read_at=n.read_at,
+            created_at=n.created_at,
+        )
+        for n in result.all()
+    ]
+
+
+@router.get("/unread-count", response_model=UnreadCountOut)
+async def unread_count(
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> UnreadCountOut:
+    stmt = (
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.user_id == auth.user.id)
+        .where(Notification.read_at.is_(None))
+    )
+    count = await session.scalar(stmt)
+    return UnreadCountOut(unread=int(count or 0))
+
+
+@router.post("/{notification_id}/read", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_notification_read(
+    notification_id: str,
+    auth: AuthContext = Depends(get_current_auth_context),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    result = await session.execute(
+        update(Notification)
+        .where(Notification.id == notification_id)
+        .where(Notification.user_id == auth.user.id)
+        .where(Notification.read_at.is_(None))
+        .values(read_at=func.now())
+    )
+    if result.rowcount == 0:
+        # Either does not exist, belongs to another user, or was already read.
+        existing = await session.scalar(
+            select(Notification).where(
+                Notification.id == notification_id,
+                Notification.user_id == auth.user.id,
+            )
+        )
+        if existing is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+    await session.commit()

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import (
     ConsentAccessLevel,
     ConsentScope,
+    ConsentShare,
     Report,
     ReportFinding,
     ReportSourceKind,
@@ -16,17 +18,16 @@ from app.db.models import (
 from app.db.session import get_db_session
 from app.dependencies.auth import AuthContext, get_current_auth_context
 from app.dependencies.reports import get_accessible_report
-from app.services.trends import BiomarkerTrend, build_trends_for_patient
 from app.services.reports import (
     ReportFindingCreateInput,
     ReportServiceError,
-    ClinicianSharedReportItem,
     create_report_for_user,
     get_clinician_shared_reports,
     list_reports_for_user,
     revoke_report_share,
     share_report_with_user,
 )
+from app.services.trends import BiomarkerTrend, build_trends_for_patient
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
-from sqlalchemy import select
+from pydantic import BaseModel
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db.models import (
+    ConsentScope,
+    ConsentShare,
     ConversationThread,
     MessageKind,
+    Notification,
+    NotificationKind,
     Report,
+    ReportFinding,
     ThreadMessage,
     ThreadParticipant,
     User,
+    UserRole,
 )
 from app.db.session import get_db_session
 from app.dependencies.auth import AuthContext, get_current_auth_context
@@ -43,6 +49,7 @@ class ThreadMessageOut(BaseModel):
     id: str
     author_user_id: str
     author_name: str
+    author_role: str
     kind: str
     body: str
     created_at: datetime
@@ -51,6 +58,8 @@ class ThreadMessageOut(BaseModel):
 class ConversationThreadOut(BaseModel):
     id: str
     report_id: str | None
+    finding_id: str | None
+    finding_label: str | None = None
     subject_user_id: str
     title: str | None
     status: str
@@ -61,6 +70,142 @@ class ConversationThreadOut(BaseModel):
 class CreateThreadRequest(BaseModel):
     title: str | None = None
     initial_message: str
+    finding_id: str | None = None
+
+
+def _primary_role(user: User | None) -> str:
+    if user is None:
+        return "unknown"
+    role_names = [assignment.role.name for assignment in user.role_assignments if assignment.role]
+    for preferred in ("clinician", "caregiver", "patient"):
+        if preferred in role_names:
+            return preferred
+    return role_names[0] if role_names else "unknown"
+
+
+def _finding_label(finding: ReportFinding | None) -> str | None:
+    if finding is None:
+        return None
+    value = finding.value_numeric if finding.value_numeric is not None else finding.value_text
+    unit = f" {finding.unit}" if finding.unit else ""
+    return f"{finding.display_name} ({value}{unit})" if value is not None else finding.display_name
+
+
+async def _has_share_access(
+    session: AsyncSession,
+    *,
+    thread: ConversationThread,
+    user_id: str,
+) -> bool:
+    if thread.report_id is None:
+        return False
+    now = datetime.now(UTC)
+    share = await session.scalar(
+        select(ConsentShare)
+        .where(
+            ConsentShare.subject_user_id == thread.subject_user_id,
+            ConsentShare.grantee_user_id == user_id,
+            ConsentShare.revoked_at.is_(None),
+            ConsentShare.expires_at > now,
+            or_(
+                and_(
+                    ConsentShare.scope == ConsentScope.PATIENT,
+                    ConsentShare.report_id.is_(None),
+                ),
+                and_(
+                    ConsentShare.scope == ConsentScope.REPORT,
+                    ConsentShare.report_id == thread.report_id,
+                ),
+            ),
+        )
+        .limit(1)
+    )
+    return share is not None
+
+
+async def _ensure_participant(
+    session: AsyncSession,
+    thread: ConversationThread,
+    user: User,
+) -> ThreadParticipant:
+    existing = await session.scalar(
+        select(ThreadParticipant).where(
+            ThreadParticipant.thread_id == thread.id,
+            ThreadParticipant.user_id == user.id,
+        )
+    )
+    if existing:
+        return existing
+    participant = ThreadParticipant(thread_id=thread.id, user_id=user.id)
+    session.add(participant)
+    await session.flush()
+    return participant
+
+
+async def _notify_other_participants(
+    session: AsyncSession,
+    thread: ConversationThread,
+    *,
+    actor_id: str,
+    message_body_preview: str,
+) -> None:
+    stmt = (
+        select(ThreadParticipant)
+        .where(ThreadParticipant.thread_id == thread.id)
+        .where(ThreadParticipant.user_id != actor_id)
+    )
+    result = await session.scalars(stmt)
+    recipients = list(result.all())
+
+    # Ensure the thread subject is always notified on incoming messages
+    # they do not author — even before they have been registered as a participant.
+    if thread.subject_user_id != actor_id and not any(p.user_id == thread.subject_user_id for p in recipients):
+        recipients.append(ThreadParticipant(thread_id=thread.id, user_id=thread.subject_user_id))
+
+    for participant in recipients:
+        session.add(
+            Notification(
+                user_id=participant.user_id,
+                thread_id=thread.id,
+                report_id=thread.report_id,
+                kind=NotificationKind.THREAD_REPLY,
+                title=thread.title or "New reply on your report",
+                payload={
+                    "thread_id": thread.id,
+                    "report_id": thread.report_id,
+                    "finding_id": thread.finding_id,
+                    "preview": message_body_preview[:160],
+                    "actor_user_id": actor_id,
+                },
+            )
+        )
+
+
+def _serialize_message(message: ThreadMessage) -> ThreadMessageOut:
+    return ThreadMessageOut(
+        id=message.id,
+        author_user_id=message.author_user_id,
+        author_name=message.author_user.display_name if message.author_user else "Unknown",
+        author_role=_primary_role(message.author_user),
+        kind=message.kind.value,
+        body=message.body,
+        created_at=message.created_at,
+    )
+
+
+def _serialize_thread(thread: ConversationThread) -> ConversationThreadOut:
+    messages = sorted(thread.messages, key=lambda m: m.created_at)
+    return ConversationThreadOut(
+        id=thread.id,
+        report_id=thread.report_id,
+        finding_id=thread.finding_id,
+        finding_label=_finding_label(thread.finding),
+        subject_user_id=thread.subject_user_id,
+        title=thread.title,
+        status=thread.status.value,
+        created_at=thread.created_at,
+        messages=[_serialize_message(m) for m in messages],
+    )
 
 
 @router.get("/reports/{report_id}/threads", response_model=list[ConversationThreadOut])
@@ -73,57 +218,57 @@ async def list_report_threads(
         select(ConversationThread)
         .where(ConversationThread.report_id == report.id)
         .order_by(ConversationThread.created_at.desc())
-        .options(selectinload(ConversationThread.messages).selectinload(ThreadMessage.author_user))
+        .options(
+            selectinload(ConversationThread.messages)
+            .selectinload(ThreadMessage.author_user)
+            .selectinload(User.role_assignments)
+            .selectinload(UserRole.role),
+            selectinload(ConversationThread.finding),
+        )
     )
     result = await session.scalars(stmt)
-    threads = result.all()
-
-    out = []
-    for thread in threads:
-        messages = sorted(thread.messages, key=lambda m: m.created_at)
-        msgs_out = [
-            ThreadMessageOut(
-                id=m.id,
-                author_user_id=m.author_user_id,
-                author_name=m.author_user.display_name if m.author_user else "Unknown",
-                kind=m.kind.value,
-                body=m.body,
-                created_at=m.created_at,
-            )
-            for m in messages
-        ]
-        out.append(
-            ConversationThreadOut(
-                id=thread.id,
-                report_id=thread.report_id,
-                subject_user_id=thread.subject_user_id,
-                title=thread.title,
-                status=thread.status.value,
-                created_at=thread.created_at,
-                messages=msgs_out,
-            )
-        )
-    return out
+    return [_serialize_thread(thread) for thread in result.all()]
 
 
-@router.post("/reports/{report_id}/threads", response_model=ConversationThreadOut, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/reports/{report_id}/threads",
+    response_model=ConversationThreadOut,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_thread(
     payload: CreateThreadRequest,
     report: Report = Depends(get_accessible_report),
     auth: AuthContext = Depends(get_current_auth_context),
     session: AsyncSession = Depends(get_db_session),
 ) -> ConversationThreadOut:
+    finding: ReportFinding | None = None
+    if payload.finding_id:
+        finding = await session.scalar(
+            select(ReportFinding).where(
+                ReportFinding.id == payload.finding_id,
+                ReportFinding.report_id == report.id,
+            )
+        )
+        if finding is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Finding does not belong to this report.",
+            )
+
     thread = ConversationThread(
         subject_user_id=report.subject_user_id,
         created_by_user_id=auth.user.id,
         report_id=report.id,
+        finding_id=finding.id if finding else None,
         title=payload.title or "Questions for Clinician",
     )
     session.add(thread)
     await session.flush()
 
-    participant = ThreadParticipant(thread_id=thread.id, user_id=auth.user.id)
-    session.add(participant)
+    session.add(ThreadParticipant(thread_id=thread.id, user_id=auth.user.id))
+    if thread.subject_user_id != auth.user.id:
+        session.add(ThreadParticipant(thread_id=thread.id, user_id=thread.subject_user_id))
+    await session.flush()
 
     message = ThreadMessage(
         thread_id=thread.id,
@@ -132,27 +277,32 @@ async def create_thread(
         body=payload.initial_message,
     )
     session.add(message)
-    await session.commit()
-    await session.refresh(thread)
+    await session.flush()
 
-    return ConversationThreadOut(
-        id=thread.id,
-        report_id=thread.report_id,
-        subject_user_id=thread.subject_user_id,
-        title=thread.title,
-        status=thread.status.value,
-        created_at=thread.created_at,
-        messages=[
-            ThreadMessageOut(
-                id=message.id,
-                author_user_id=message.author_user_id,
-                author_name=auth.user.display_name,
-                kind=message.kind.value,
-                body=message.body,
-                created_at=message.created_at,
-            )
-        ],
+    await _notify_other_participants(
+        session,
+        thread,
+        actor_id=auth.user.id,
+        message_body_preview=payload.initial_message,
     )
+
+    await session.commit()
+
+    # Reload with all relationships needed for serialization.
+    stmt = (
+        select(ConversationThread)
+        .where(ConversationThread.id == thread.id)
+        .options(
+            selectinload(ConversationThread.messages)
+            .selectinload(ThreadMessage.author_user)
+            .selectinload(User.role_assignments)
+            .selectinload(UserRole.role),
+            selectinload(ConversationThread.finding),
+        )
+    )
+    loaded = await session.scalar(stmt)
+    assert loaded is not None
+    return _serialize_thread(loaded)
 
 
 class AddMessageRequest(BaseModel):
@@ -160,16 +310,33 @@ class AddMessageRequest(BaseModel):
     template_payload: dict[str, Any] | None = None
 
 
-@router.post("/threads/{thread_id}/messages", response_model=ThreadMessageOut, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/threads/{thread_id}/messages",
+    response_model=ThreadMessageOut,
+    status_code=status.HTTP_201_CREATED,
+)
 async def add_message(
     thread_id: str,
     payload: AddMessageRequest,
     auth: AuthContext = Depends(get_current_auth_context),
     session: AsyncSession = Depends(get_db_session),
 ) -> ThreadMessageOut:
-    thread = await session.scalar(select(ConversationThread).where(ConversationThread.id == thread_id))
+    thread = await session.scalar(
+        select(ConversationThread)
+        .where(ConversationThread.id == thread_id)
+        .options(selectinload(ConversationThread.participants))
+    )
     if not thread:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Thread not found")
+
+    is_participant = any(p.user_id == auth.user.id for p in thread.participants)
+    is_subject = thread.subject_user_id == auth.user.id
+    if not is_participant and not is_subject:
+        if not await _has_share_access(session, thread=thread, user_id=auth.user.id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this thread.",
+            )
 
     if payload.template_payload:
         kind = MessageKind.TEMPLATE
@@ -178,7 +345,10 @@ async def add_message(
         kind = MessageKind.TEXT
         body = payload.body
     else:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Must provide body or template_payload")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Must provide body or template_payload",
+        )
 
     message = ThreadMessage(
         thread_id=thread.id,
@@ -187,24 +357,22 @@ async def add_message(
         body=body,
     )
     session.add(message)
-    
-    participant = await session.scalar(
-        select(ThreadParticipant).where(
-            ThreadParticipant.thread_id == thread.id,
-            ThreadParticipant.user_id == auth.user.id
-        )
+
+    await _ensure_participant(session, thread, auth.user)
+    await _notify_other_participants(
+        session,
+        thread,
+        actor_id=auth.user.id,
+        message_body_preview=body,
     )
-    if not participant:
-        session.add(ThreadParticipant(thread_id=thread.id, user_id=auth.user.id))
 
     await session.commit()
-    await session.refresh(message)
 
-    return ThreadMessageOut(
-        id=message.id,
-        author_user_id=message.author_user_id,
-        author_name=auth.user.display_name,
-        kind=message.kind.value,
-        body=message.body,
-        created_at=message.created_at,
+    # Reload with the author's roles so response includes author_role correctly.
+    loaded_msg = await session.scalar(
+        select(ThreadMessage)
+        .where(ThreadMessage.id == message.id)
+        .options(selectinload(ThreadMessage.author_user).selectinload(User.role_assignments))
     )
+    assert loaded_msg is not None
+    return _serialize_message(loaded_msg)

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -86,6 +86,7 @@ async def create_report_for_user(
     title: str | None,
     source_kind: ReportSourceKind,
     findings: list[ReportFindingCreateInput],
+    observed_at: datetime | None = None,
 ) -> Report:
     report = Report(
         subject_user_id=subject_user_id,
@@ -93,7 +94,7 @@ async def create_report_for_user(
         title=title,
         source_kind=source_kind,
         sharing_mode=ReportSharingMode.PRIVATE,
-        observed_at=datetime.now(UTC),
+        observed_at=observed_at or datetime.now(UTC),
     )
     session.add(report)
     await session.flush()

--- a/backend/tests/test_threads.py
+++ b/backend/tests/test_threads.py
@@ -1,91 +1,90 @@
-import pytest
-import httpx
-from datetime import datetime, UTC
-from sqlalchemy.ext.asyncio import AsyncSession
-from app.db.models import Report, ReportSourceKind, ReportSharingMode, User, ConversationThread, ThreadMessage, ThreadStatus, MessageKind
+"""Core thread endpoints — create, post messages, list, question prompts."""
 
-@pytest.fixture
-async def sample_report(db_session: AsyncSession, mock_user: User) -> Report:
-    report = Report(
-        subject_user_id=mock_user.id,
-        created_by_user_id=mock_user.id,
-        title="Test Labs",
-        source_kind=ReportSourceKind.MANUAL,
-        sharing_mode=ReportSharingMode.PRIVATE,
-        observed_at=datetime.now(UTC),
-    )
-    db_session.add(report)
-    await db_session.commit()
-    await db_session.refresh(report)
-    return report
+from __future__ import annotations
 
-@pytest.mark.asyncio
-async def test_create_and_list_threads(
-    async_client: httpx.AsyncClient, 
-    sample_report: Report,
-    auth_headers: dict[str, str]
-):
-    # 1. Create a thread
-    resp = await async_client.post(
-        f"/api/v1/reports/{sample_report.id}/threads",
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def test_create_and_list_threads(consent_api: ConsentApiHarness) -> None:
+    patient_email = "threads-core-patient@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    token = login(consent_api, email=patient_email)
+    headers = auth_headers(token)
+
+    create_resp = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/threads",
+        headers=headers,
         json={"initial_message": "What does my glucose mean?", "title": "Glucose question"},
-        headers=auth_headers
     )
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["title"] == "Glucose question"
-    assert len(data["messages"]) == 1
-    thread_id = data["id"]
-    
-    # 2. Add clinician template message
-    resp = await async_client.post(
+    assert create_resp.status_code == 201, create_resp.text
+    thread_id = create_resp.json()["id"]
+    assert create_resp.json()["title"] == "Glucose question"
+    assert len(create_resp.json()["messages"]) == 1
+
+    template_resp = consent_api.client.post(
         f"/api/v1/threads/{thread_id}/messages",
+        headers=headers,
         json={
             "template_payload": {
                 "meaning": "Your glucose is slightly high but ok.",
                 "urgency": "routine",
-                "action": "Monitor diet."
+                "action": "Monitor diet.",
             }
         },
-        headers=auth_headers
     )
-    assert resp.status_code == 201
-    msg_data = resp.json()
-    assert msg_data["kind"] == "template"
-    
-    # 3. Add text response
-    resp = await async_client.post(
+    assert template_resp.status_code == 201, template_resp.text
+    assert template_resp.json()["kind"] == "template"
+
+    text_resp = consent_api.client.post(
         f"/api/v1/threads/{thread_id}/messages",
+        headers=headers,
         json={"body": "Thank you doctor!"},
-        headers=auth_headers
     )
-    assert resp.status_code == 201
-    msg_data = resp.json()
-    assert msg_data["kind"] == "text"
-    assert msg_data["body"] == "Thank you doctor!"
-    
-    # 4. List threads
-    resp = await async_client.get(
-        f"/api/v1/reports/{sample_report.id}/threads",
-        headers=auth_headers
+    assert text_resp.status_code == 201, text_resp.text
+    assert text_resp.json()["kind"] == "text"
+    assert text_resp.json()["body"] == "Thank you doctor!"
+
+    listing = consent_api.client.get(
+        f"/api/v1/reports/{report.id}/threads",
+        headers=headers,
     )
-    assert resp.status_code == 200
-    threads = resp.json()
+    assert listing.status_code == 200, listing.text
+    threads = listing.json()
     assert len(threads) == 1
     assert len(threads[0]["messages"]) == 3
 
-@pytest.mark.asyncio
-async def test_get_question_prompts(
-    async_client: httpx.AsyncClient, 
-    sample_report: Report,
-    auth_headers: dict[str, str]
-):
-    resp = await async_client.get(
-        f"/api/v1/reports/{sample_report.id}/question-prompts",
-        headers=auth_headers
+
+def test_get_question_prompts(consent_api: ConsentApiHarness) -> None:
+    patient_email = "prompts-patient@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    token = login(consent_api, email=patient_email)
+    resp = consent_api.client.get(
+        f"/api/v1/reports/{report.id}/question-prompts",
+        headers=auth_headers(token),
     )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "prompts" in data
-    assert isinstance(data["prompts"], list)
-    assert len(data["prompts"]) >= 2
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "prompts" in body
+    assert isinstance(body["prompts"], list)
+    assert len(body["prompts"]) >= 2

--- a/backend/tests/test_threads_anchor_notifications.py
+++ b/backend/tests/test_threads_anchor_notifications.py
@@ -1,0 +1,320 @@
+"""T7 — thread anchors, notifications, and access control.
+
+These tests cover the gaps identified in the T6/T7 delivery sweep:
+- threads can be anchored to a specific finding on a report
+- unauthorized users cannot post into a thread they don't participate in
+- new messages create Notification rows for the *other* participants
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import Notification, User
+from tests.factories import PersistenceFactory
+from tests.support.consent_api import (
+    ConsentApiHarness,
+    auth_headers,
+    consent_api,
+    login,
+    seed_report,
+    seed_user,
+)
+
+
+def _future_expiry_iso(days: int = 7) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _seed_finding(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    patient_email: str,
+    biomarker: str,
+) -> str:
+    with consent_api.session_factory() as session:
+        factory = PersistenceFactory(session)
+        patient = session.scalar(select(User).where(User.email == patient_email))
+        assert patient is not None
+        report = session.get_one = None  # noqa: F841 — dummy to keep lint quiet if used
+        from app.db.models import Report as _Report  # local import to avoid cycles above
+        report_obj = session.scalar(select(_Report).where(_Report.id == report_id))
+        assert report_obj is not None
+        finding = factory.create_finding(
+            report=report_obj,
+            patient=patient,
+            biomarker_key=biomarker,
+            display_name=biomarker.title(),
+            value_numeric=6.2,
+            unit="mmol/L",
+            flag="high",
+            reference_low=3.9,
+            reference_high=5.5,
+        )
+        session.commit()
+        return finding.id
+
+
+def _create_thread(
+    consent_api: ConsentApiHarness,
+    *,
+    report_id: str,
+    token: str,
+    initial_message: str = "What does this result mean?",
+    finding_id: str | None = None,
+    title: str | None = None,
+) -> dict:
+    body: dict = {"initial_message": initial_message}
+    if finding_id is not None:
+        body["finding_id"] = finding_id
+    if title is not None:
+        body["title"] = title
+    response = consent_api.client.post(
+        f"/api/v1/reports/{report_id}/threads",
+        headers=auth_headers(token),
+        json=body,
+    )
+    return response
+
+
+def test_thread_can_be_anchored_to_a_finding(consent_api: ConsentApiHarness) -> None:
+    patient_email = "anchor-patient@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    finding_id = _seed_finding(
+        consent_api,
+        report_id=report.id,
+        patient_email=patient_email,
+        biomarker="glucose",
+    )
+    patient_token = login(consent_api, email=patient_email)
+
+    response = _create_thread(
+        consent_api,
+        report_id=report.id,
+        token=patient_token,
+        finding_id=finding_id,
+    )
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert data["finding_id"] == finding_id
+    assert data["finding_label"] and "Glucose" in data["finding_label"]
+
+
+def test_thread_rejects_unknown_finding(consent_api: ConsentApiHarness) -> None:
+    patient_email = "anchor-bad-patient@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    response = _create_thread(
+        consent_api,
+        report_id=report.id,
+        token=patient_token,
+        finding_id="00000000-0000-0000-0000-000000000000",
+    )
+    assert response.status_code == 400, response.text
+
+
+def test_thread_creation_notifies_authorized_clinician(consent_api: ConsentApiHarness) -> None:
+    patient_email = "notify-patient@example.com"
+    clinician_email = "notify-clinician@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+        patient_id = patient.id
+
+    patient_token = login(consent_api, email=patient_email)
+
+    # Patient grants the clinician access, then creates a thread.
+    share_resp = consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "report",
+            "access_level": "comment",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+    assert share_resp.status_code == 201, share_resp.text
+
+    thread_resp = _create_thread(
+        consent_api,
+        report_id=report.id,
+        token=patient_token,
+        title="Glucose question",
+    )
+    assert thread_resp.status_code == 201, thread_resp.text
+    thread_id = thread_resp.json()["id"]
+
+    # Clinician reply should land as a notification on the patient.
+    clinician_token = login(consent_api, email=clinician_email)
+    reply = consent_api.client.post(
+        f"/api/v1/threads/{thread_id}/messages",
+        headers=auth_headers(clinician_token),
+        json={"body": "Slight elevation, recheck in 3 months."},
+    )
+    assert reply.status_code == 201, reply.text
+
+    # The patient now has a notification for the clinician reply.
+    notifications = consent_api.client.get(
+        "/api/v1/notifications",
+        headers=auth_headers(patient_token),
+    )
+    assert notifications.status_code == 200, notifications.text
+    payloads = notifications.json()
+    assert any(n.get("thread_id") == thread_id for n in payloads)
+
+    unread = consent_api.client.get(
+        "/api/v1/notifications/unread-count",
+        headers=auth_headers(patient_token),
+    )
+    assert unread.status_code == 200
+    assert unread.json()["unread"] >= 1
+
+    # Verify row was really written against the patient.
+    with consent_api.session_factory() as session:
+        rows = session.scalars(
+            select(Notification).where(Notification.user_id == patient_id)
+        ).all()
+        assert len(rows) >= 1
+
+
+def test_message_endpoint_rejects_non_participants(consent_api: ConsentApiHarness) -> None:
+    patient_email = "access-patient@example.com"
+    stranger_email = "access-stranger@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=stranger_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    thread_resp = _create_thread(
+        consent_api, report_id=report.id, token=patient_token
+    )
+    assert thread_resp.status_code == 201, thread_resp.text
+    thread_id = thread_resp.json()["id"]
+
+    stranger_token = login(consent_api, email=stranger_email)
+    reply = consent_api.client.post(
+        f"/api/v1/threads/{thread_id}/messages",
+        headers=auth_headers(stranger_token),
+        json={"body": "I should not be able to post."},
+    )
+    assert reply.status_code == 403, reply.text
+
+
+def test_messages_are_returned_in_chronological_order(consent_api: ConsentApiHarness) -> None:
+    patient_email = "ordering-patient@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    thread_resp = _create_thread(
+        consent_api,
+        report_id=report.id,
+        token=patient_token,
+        initial_message="first",
+    )
+    thread_id = thread_resp.json()["id"]
+
+    for idx, body in enumerate(["second", "third"], start=2):
+        reply = consent_api.client.post(
+            f"/api/v1/threads/{thread_id}/messages",
+            headers=auth_headers(patient_token),
+            json={"body": body},
+        )
+        assert reply.status_code == 201, reply.text
+        assert reply.json()["author_role"] == "patient"
+
+    listing = consent_api.client.get(
+        f"/api/v1/reports/{report.id}/threads",
+        headers=auth_headers(patient_token),
+    )
+    assert listing.status_code == 200
+    bodies = [m["body"] for m in listing.json()[0]["messages"]]
+    assert bodies == ["first", "second", "third"]
+
+
+def test_mark_notification_as_read(consent_api: ConsentApiHarness) -> None:
+    patient_email = "read-patient@example.com"
+    clinician_email = "read-clinician@example.com"
+    with consent_api.session_factory() as session:
+        patient = seed_user(session, email=patient_email, role="patient")
+        seed_user(session, email=clinician_email, role="clinician")
+        report = seed_report(
+            session,
+            subject_email=patient.email,
+            created_by_email=patient.email,
+        )
+
+    patient_token = login(consent_api, email=patient_email)
+    consent_api.client.post(
+        f"/api/v1/reports/{report.id}/share",
+        headers=auth_headers(patient_token),
+        json={
+            "clinician_email": clinician_email,
+            "scope": "report",
+            "access_level": "comment",
+            "expires_at": _future_expiry_iso(),
+        },
+    )
+
+    thread_resp = _create_thread(
+        consent_api, report_id=report.id, token=patient_token
+    )
+    thread_id = thread_resp.json()["id"]
+
+    clinician_token = login(consent_api, email=clinician_email)
+    consent_api.client.post(
+        f"/api/v1/threads/{thread_id}/messages",
+        headers=auth_headers(clinician_token),
+        json={"body": "Reply from clinician."},
+    )
+
+    listing = consent_api.client.get(
+        "/api/v1/notifications",
+        headers=auth_headers(patient_token),
+    )
+    notif_id = listing.json()[0]["id"]
+
+    read_resp = consent_api.client.post(
+        f"/api/v1/notifications/{notif_id}/read",
+        headers=auth_headers(patient_token),
+    )
+    assert read_resp.status_code == 204
+
+    unread = consent_api.client.get(
+        "/api/v1/notifications/unread-count",
+        headers=auth_headers(patient_token),
+    )
+    assert unread.json()["unread"] == 0

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -11,6 +11,8 @@ import { DoctorSummaryDocument, type SummaryFinding, type SummaryThread } from '
 import Disclaimer from '@/components/Disclaimer';
 import { BiomarkerTrendChart } from '@/components/BiomarkerTrendChart';
 import { fetchReportTrends, type BiomarkerTrend } from '@/lib/reportTrends';
+import { AuditLogTimeline } from '@/components/AuditLogTimeline';
+import { shareStateFrom, type ShareLifecycleState } from '@/lib/auditLog';
 function formatDate(ts: number) {
   return new Date(ts).toLocaleString();
 }
@@ -20,6 +22,13 @@ const defaultSharingPreferences: SharingPreferences = {
   scope: 'summary',
   expiresAt: Date.now() + 86400000,
   active: false,
+};
+
+const SHARE_BADGE: Record<ShareLifecycleState, { label: string; color: string; background: string; border: string }> = {
+  active: { label: 'Active', color: '#047857', background: '#ecfdf5', border: '#a7f3d0' },
+  expired: { label: 'Expired', color: '#9a3412', background: '#fff7ed', border: '#fed7aa' },
+  revoked: { label: 'Revoked', color: '#b91c1c', background: '#fef2f2', border: '#fecaca' },
+  inactive: { label: 'Not shared', color: '#374151', background: '#f9fafb', border: '#e5e7eb' },
 };
 
 const LANGUAGE_OPTIONS = [
@@ -39,6 +48,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
   // FR13 state
   const [includeSummaryPDF, setIncludeSummaryPDF] = useState(false);
   const [threads, setThreads] = useState<ConversationThread[]>([]);
+  const [auditReloadToken, setAuditReloadToken] = useState(0);
 
   // Trend states
   const [trends, setTrends] = useState<BiomarkerTrend[]>([]);
@@ -240,6 +250,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
       updateReportInHistory(report.id, { sharingPreferences: updatedPrefs });
       setReport({ ...report, sharingPreferences: updatedPrefs });
       setStatusMessage('Sharing preferences updated.');
+      setAuditReloadToken((n) => n + 1);
     } catch (err) {
       setStatusMessage('Unable to save sharing preferences. Please try again.');
     }
@@ -277,6 +288,7 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
       updateReportInHistory(report.id, { sharingPreferences: resetPrefs });
       setReport({ ...report, sharingPreferences: resetPrefs });
       setStatusMessage('Sharing revoked.');
+      setAuditReloadToken((n) => n + 1);
     } catch {
       setStatusMessage('Unable to revoke sharing preferences. Please try again.');
     }
@@ -306,6 +318,10 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
   const selectedTrend = filteredTrendItems.find((item) => item.biomarker_key === selectedBiomarkerKey)
     || filteredTrendItems[0]
     || null;
+
+  const shareState: ShareLifecycleState = shareStateFrom(
+    { active: sharingPreferences.active, expiresAt: sharingPreferences.expiresAt },
+  );
 
   if (!user) {
     return (
@@ -492,8 +508,36 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
           ) : null}
         </div>
 
-        <div className="card">
-          <h2>Sharing Preferences</h2>
+        <div className="card" data-testid="sharing-card" data-share-state={shareState}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+            <h2 style={{ margin: 0 }}>Sharing Preferences</h2>
+            <span
+              data-testid="share-state-badge"
+              style={{
+                padding: '0.2rem 0.6rem',
+                borderRadius: '999px',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                color: SHARE_BADGE[shareState].color,
+                background: SHARE_BADGE[shareState].background,
+                border: `1px solid ${SHARE_BADGE[shareState].border}`,
+              }}
+            >
+              {SHARE_BADGE[shareState].label}
+            </span>
+          </div>
+          {shareState === 'expired' ? (
+            <p role="status" data-testid="share-expired-message" style={{ color: '#9a3412', marginTop: '0.5rem' }}>
+              This share has expired. Clinician access was removed automatically.
+            </p>
+          ) : null}
+          {shareState === 'revoked' ? (
+            <p role="status" data-testid="share-revoked-message" style={{ color: '#b91c1c', marginTop: '0.5rem' }}>
+              This share was revoked. Clinician access is no longer allowed.
+            </p>
+          ) : null}
           <div className="field">
             <label htmlFor="clinician-email">Clinician Email</label>
             <input
@@ -540,6 +584,8 @@ export default function ReportDetailPage({ params }: { params: { reportId: strin
           {sharingPreferences.active && <button className="nav-btn nav-btn-danger" onClick={revokeShare} style={{ marginLeft: '0.5rem' }}>Revoke</button>}
           {statusMessage && <p>{statusMessage}</p>}
         </div>
+
+        <AuditLogTimeline reportId={report.id} reloadToken={auditReloadToken} />
 
         <Disclaimer />
 

--- a/frontend/src/components/AuditLogTimeline.tsx
+++ b/frontend/src/components/AuditLogTimeline.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  fetchReportAuditLog,
+  describeAuditAction,
+  type AuditEvent,
+} from '@/lib/auditLog';
+
+type Props = {
+  reportId: string;
+  reloadToken?: number;
+};
+
+function eventAccent(action: string): { bg: string; border: string; dot: string; label: string } {
+  switch (action) {
+    case 'created':
+      return { bg: '#ecfdf5', border: '#34d399', dot: '#059669', label: '#047857' };
+    case 'revoked':
+      return { bg: '#fef2f2', border: '#f87171', dot: '#dc2626', label: '#b91c1c' };
+    case 'expired':
+      return { bg: '#fff7ed', border: '#fb923c', dot: '#c2410c', label: '#9a3412' };
+    case 'view':
+      return { bg: '#eff6ff', border: '#60a5fa', dot: '#1d4ed8', label: '#1e40af' };
+    default:
+      return { bg: '#f9fafb', border: '#d1d5db', dot: '#6b7280', label: '#374151' };
+  }
+}
+
+function formatTime(iso: string): string {
+  const ts = new Date(iso);
+  if (Number.isNaN(ts.getTime())) return iso;
+  return ts.toLocaleString();
+}
+
+function contextSummary(event: AuditEvent): string | null {
+  const ctx = event.context ?? {};
+  const parts: string[] = [];
+  if (typeof ctx.grantee_email === 'string') parts.push(`recipient: ${ctx.grantee_email}`);
+  if (typeof ctx.scope === 'string') parts.push(`scope: ${ctx.scope}`);
+  if (typeof ctx.access_level === 'string') parts.push(`access: ${ctx.access_level}`);
+  return parts.length > 0 ? parts.join(' • ') : null;
+}
+
+export function AuditLogTimeline({ reportId, reloadToken = 0 }: Props) {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchReportAuditLog(reportId)
+      .then((payload) => {
+        if (!cancelled) setEvents(payload);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Unable to load audit log.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reportId, reloadToken]);
+
+  return (
+    <div className="card" data-testid="audit-log-timeline">
+      <h2 style={{ margin: 0 }}>Sharing Activity</h2>
+      <p style={{ color: '#6b7280', fontSize: '0.85rem', marginTop: '0.25rem' }}>
+        Every share, revocation, view, and expiry is recorded here in chronological order.
+      </p>
+
+      {loading ? <p>Loading activity…</p> : null}
+      {!loading && error ? (
+        <p role="alert" style={{ color: '#b91c1c' }}>{error}</p>
+      ) : null}
+      {!loading && !error && events.length === 0 ? (
+        <p style={{ color: '#6b7280' }}>No sharing activity recorded for this report yet.</p>
+      ) : null}
+
+      {events.length > 0 ? (
+        <ol
+          role="list"
+          style={{
+            listStyle: 'none',
+            padding: 0,
+            margin: '0.75rem 0 0',
+            borderLeft: '2px solid #e5e7eb',
+            paddingLeft: '1rem',
+          }}
+        >
+          {events.map((event) => {
+            const accent = eventAccent(event.action);
+            const summary = contextSummary(event);
+            return (
+              <li
+                key={event.event_id}
+                data-testid={`audit-event-${event.action}`}
+                style={{
+                  position: 'relative',
+                  padding: '0.75rem 0.9rem',
+                  marginBottom: '0.75rem',
+                  background: accent.bg,
+                  borderRadius: '8px',
+                  borderLeft: `4px solid ${accent.border}`,
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    position: 'absolute',
+                    left: '-1.45rem',
+                    top: '1rem',
+                    width: '0.75rem',
+                    height: '0.75rem',
+                    borderRadius: '50%',
+                    background: accent.dot,
+                    boxShadow: '0 0 0 3px #fff',
+                  }}
+                />
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+                  <strong style={{ color: accent.label }}>{describeAuditAction(event.action)}</strong>
+                  <time dateTime={event.occurred_at} style={{ color: '#4b5563', fontSize: '0.85rem' }}>
+                    {formatTime(event.occurred_at)}
+                  </time>
+                </div>
+                {summary ? (
+                  <div style={{ color: '#374151', fontSize: '0.9rem', marginTop: '0.25rem' }}>{summary}</div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/AuditLogTimeline.test.tsx
+++ b/frontend/src/components/__tests__/AuditLogTimeline.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuditLogTimeline } from '../AuditLogTimeline';
+
+const SAMPLE_EVENTS = [
+  {
+    event_id: 'b',
+    action: 'revoked',
+    occurred_at: '2026-04-18T12:05:00Z',
+    context: { grantee_email: 'doc@example.com', scope: 'report', access_level: 'read' },
+  },
+  {
+    event_id: 'a',
+    action: 'created',
+    occurred_at: '2026-04-18T12:00:00Z',
+    context: { grantee_email: 'doc@example.com', scope: 'report', access_level: 'read' },
+  },
+];
+
+function storeSession() {
+  window.localStorage.setItem(
+    'reportx_session',
+    JSON.stringify({ accessToken: 'test-token' }),
+  );
+}
+
+describe('AuditLogTimeline', () => {
+  beforeEach(() => {
+    storeSession();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => SAMPLE_EVENTS,
+        text: async () => JSON.stringify(SAMPLE_EVENTS),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders events in chronological order (oldest first)', async () => {
+    render(<AuditLogTimeline reportId="report-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-log-timeline')).toBeInTheDocument();
+      expect(screen.getByText(/Share created/i)).toBeInTheDocument();
+    });
+
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent(/Share created/i);
+    expect(items[1]).toHaveTextContent(/Share revoked/i);
+  });
+
+  it('renders distinct styling for revoked events', async () => {
+    render(<AuditLogTimeline reportId="report-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-event-revoked')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('audit-event-created')).toBeInTheDocument();
+  });
+
+  it('surfaces an error message when the fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+        text: async () => 'boom',
+      })),
+    );
+
+    render(<AuditLogTimeline reportId="report-1" />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/audit log request failed/i);
+    });
+  });
+
+  it('shows an empty-state message when there are no events', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => [],
+        text: async () => '[]',
+      })),
+    );
+
+    render(<AuditLogTimeline reportId="report-1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/no sharing activity/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/lib/auditLog.test.ts
+++ b/frontend/src/lib/auditLog.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeAuditAction, shareStateFrom } from './auditLog';
+
+describe('describeAuditAction', () => {
+  it.each([
+    ['created', 'Share created'],
+    ['revoked', 'Share revoked'],
+    ['expired', 'Share expired'],
+    ['view', 'Clinician viewed report'],
+  ])('describes %s', (action, expected) => {
+    expect(describeAuditAction(action)).toBe(expected);
+  });
+
+  it('falls back to a humanised form for unknown actions', () => {
+    expect(describeAuditAction('policy_changed')).toBe('policy changed');
+  });
+});
+
+describe('shareStateFrom', () => {
+  const now = new Date('2026-04-18T12:00:00Z').getTime();
+
+  it('returns inactive when prefs are undefined', () => {
+    expect(shareStateFrom(undefined, now)).toBe('inactive');
+  });
+
+  it('returns inactive when active flag is false', () => {
+    expect(shareStateFrom({ active: false, expiresAt: now + 10_000 }, now)).toBe('inactive');
+  });
+
+  it('returns expired when the share is active but past expiry', () => {
+    expect(shareStateFrom({ active: true, expiresAt: now - 1 }, now)).toBe('expired');
+  });
+
+  it('returns active when the share is active and not past expiry', () => {
+    expect(shareStateFrom({ active: true, expiresAt: now + 5_000 }, now)).toBe('active');
+  });
+});

--- a/frontend/src/lib/auditLog.ts
+++ b/frontend/src/lib/auditLog.ts
@@ -1,0 +1,73 @@
+export type AuditAction = 'created' | 'revoked' | 'expired' | 'view' | string;
+
+export type AuditEvent = {
+  event_id: string;
+  action: AuditAction;
+  occurred_at: string;
+  context: Record<string, unknown>;
+};
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+function getAccessToken(): string | null {
+  if (!isBrowser) return null;
+  try {
+    const raw = window.localStorage.getItem('reportx_session');
+    if (!raw) return null;
+    return JSON.parse(raw)?.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchReportAuditLog(reportId: string): Promise<AuditEvent[]> {
+  if (!reportId?.trim()) {
+    throw new Error('reportId is required');
+  }
+  const token = getAccessToken();
+  if (!token) {
+    throw new Error('User is not authenticated.');
+  }
+
+  const response = await fetch(
+    `${BACKEND_URL}/api/v1/audit/reports/${encodeURIComponent(reportId)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Audit log request failed: ${response.status} ${text}`);
+  }
+  const data = (await response.json()) as AuditEvent[];
+  // Defensive copy + chronological sort (oldest first) so the UI timeline is deterministic.
+  return [...data].sort(
+    (a, b) => new Date(a.occurred_at).getTime() - new Date(b.occurred_at).getTime(),
+  );
+}
+
+export function describeAuditAction(action: string): string {
+  switch (action) {
+    case 'created':
+      return 'Share created';
+    case 'revoked':
+      return 'Share revoked';
+    case 'expired':
+      return 'Share expired';
+    case 'view':
+      return 'Clinician viewed report';
+    default:
+      return action.replace(/_/g, ' ');
+  }
+}
+
+export type ShareLifecycleState = 'active' | 'expired' | 'revoked' | 'inactive';
+
+export function shareStateFrom(
+  prefs: { active?: boolean; expiresAt?: number } | undefined,
+  now: number = Date.now(),
+): ShareLifecycleState {
+  if (!prefs) return 'inactive';
+  if (!prefs.active) return 'inactive';
+  if (prefs.expiresAt && prefs.expiresAt < now) return 'expired';
+  return 'active';
+}


### PR DESCRIPTION
T7 backend
- Add finding_id column to conversation_threads with migration 20260418_02
- POST /reports/{id}/threads accepts optional finding_id and validates that the finding belongs to the report
- POST /threads/{id}/messages now verifies the caller is a participant, subject, or has an active consent share; unauthorized callers get 403
- Message creation emits Notification rows for every other participant and the thread subject, scoped by thread/report
- Thread serialization returns finding_label, finding_id, and author_role
- New /api/v1/notifications router: list, unread-count, mark-read
- Rewrote test_threads.py to use the working consent_api harness
- New tests in test_threads_anchor_notifications.py cover anchor validation, notification generation, access control, chronological ordering, and read/unread behaviour

T6 frontend
- New AuditLogTimeline component renders share/view/revoke/expire events chronologically, with per-action accent styling
- New lib/auditLog.ts helper with fetchReportAuditLog, describeAuditAction, and shareStateFrom lifecycle classifier
- Report detail page now shows a share-state badge (Active / Expired / Revoked / Not shared) and explicit expired/revoked messaging
- Audit timeline reloads after share/revoke actions
- Unit + integration tests for timeline rendering, empty/error states, and lifecycle classifier

Cleanup on main
- Fix missing UTC import and missing select/ConsentShare imports in reports.py (breaking two pre-existing tests)
- Add observed_at kwarg to create_report_for_user so the reports router signature matches