### PR TITLE
feat : Longitudinal Trend Analysis Backend and Sparkline-Ready API 

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import (
+    ConsentShare,
     ConsentAccessLevel,
     ConsentScope,
     Report,
@@ -96,6 +98,8 @@ class TrendPointOut(BaseModel):
     value: float
     unit: str | None
     flag: str
+    reference_low: float | None
+    reference_high: float | None
 
 
 class BiomarkerTrendOut(BaseModel):
@@ -111,6 +115,8 @@ class ReportTrendsResponse(BaseModel):
     report_id: str
     subject_user_id: str
     trends: list[BiomarkerTrendOut]
+
+
 def _raise_report_http_error(exc: ReportServiceError) -> None:
     raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 
@@ -352,6 +358,8 @@ def _trend_out(trend: BiomarkerTrend) -> BiomarkerTrendOut:
                 value=point.value,
                 unit=point.unit,
                 flag=point.flag.value,
+                reference_low=point.reference_low,
+                reference_high=point.reference_high,
             )
             for point in trend.points
         ],

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -85,6 +85,7 @@ async def create_report_for_user(
     created_by_user_id: str,
     title: str | None,
     source_kind: ReportSourceKind,
+    observed_at: datetime,
     findings: list[ReportFindingCreateInput],
 ) -> Report:
     report = Report(
@@ -93,7 +94,7 @@ async def create_report_for_user(
         title=title,
         source_kind=source_kind,
         sharing_mode=ReportSharingMode.PRIVATE,
-        observed_at=datetime.now(UTC),
+        observed_at=observed_at,
     )
     session.add(report)
     await session.flush()
@@ -525,5 +526,4 @@ async def cleanup_expired_shares(session: AsyncSession) -> int:
     
     await session.commit()
     return cleaned_count
-
 

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -59,6 +59,15 @@ def _is_quantitative_finding(finding: ReportFinding) -> bool:
     return name not in NON_QUANTITATIVE_MARKER_NAME
 
 
+def _has_consistent_units(findings: list[tuple[ReportFinding, Report]]) -> bool:
+    normalized_units = {
+        (finding.unit or "").strip().lower()
+        for finding, _ in findings
+        if (finding.unit or "").strip()
+    }
+    return len(normalized_units) <= 1
+
+
 def _flag_severity(flag: FindingFlag) -> int:
     if flag is FindingFlag.NORMAL:
         return 0
@@ -157,6 +166,9 @@ async def build_trends_for_patient(
 
     trends: list[BiomarkerTrend] = []
     for biomarker_key, entries in grouped.items():
+        if not _has_consistent_units(entries):
+            continue
+
         # Collapse to one finding per report, picking the most clinically relevant
         by_report: dict[str, list[tuple[ReportFinding, Report]]] = {}
         for finding, report in entries:

--- a/backend/tests/test_trends_api.py
+++ b/backend/tests/test_trends_api.py
@@ -105,6 +105,7 @@ def create_report_with_findings(
     observed_at: datetime,
     hemoglobin_value: float,
     hemoglobin_flag: str,
+    hemoglobin_unit: str = "g/dL",
     include_singleton_biomarker: bool = False,
     include_report_date_numeric_finding: bool = False,
 ) -> str:
@@ -126,7 +127,7 @@ def create_report_with_findings(
             biomarker_key="hemoglobin",
             display_name="Hemoglobin",
             value_numeric=hemoglobin_value,
-            unit="g/dL",
+            unit=hemoglobin_unit,
             flag=hemoglobin_flag,
             reference_low=12.0,
             reference_high=15.5,
@@ -272,6 +273,43 @@ def test_trends_exclude_date_like_numeric_findings(trends_api: TrendsApiHarness)
     trend_names = {item["display_name"] for item in response.json()["trends"]}
     assert "Hemoglobin" in trend_names
     assert "Report Date" not in trend_names
+
+
+def test_trends_skip_mixed_unit_series(trends_api: TrendsApiHarness):
+    register_user(
+        trends_api,
+        email="patient.mixedunits@example.com",
+        password="Password123!",
+        role="patient",
+        display_name="Patient Mixed Units",
+    )
+
+    create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.mixedunits@example.com",
+        created_by_email="patient.mixedunits@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=12),
+        hemoglobin_value=14.2,
+        hemoglobin_flag="normal",
+        hemoglobin_unit="g/dL",
+    )
+    newer_report_id = create_report_with_findings(
+        trends_api.session_factory,
+        subject_email="patient.mixedunits@example.com",
+        created_by_email="patient.mixedunits@example.com",
+        observed_at=datetime.now(UTC) - timedelta(days=1),
+        hemoglobin_value=8.8,
+        hemoglobin_flag="normal",
+        hemoglobin_unit="mmol/L",
+    )
+
+    login = login_user(trends_api, email="patient.mixedunits@example.com", password="Password123!")
+    response = trends_api.client.get(
+        f"/api/v1/reports/{newer_report_id}/trends",
+        headers=auth_headers(login["access_token"]),
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["trends"] == []
 
 
 def test_clinician_trends_require_full_report_access(trends_api: TrendsApiHarness):


### PR DESCRIPTION
- Implemented backend trend-analysis support for FR12 via the reports API.
- Added patient trend retrieval for biomarkers appearing across multiple dated reports.
- Returned sparkline/chart-ready historical series payloads per biomarker, including report/date/value/unit/flag and reference bounds.
- Generated safe plain-language trend notes classified as `improving`, `stable`, or `worsening`.
- Prevented fabricated trends by excluding biomarkers that appear only once.
- Filtered out non-quantitative/date-like numeric findings from trend output.
- Prevented misleading trends across mixed-unit series by skipping inconsistent-unit biomarker histories.
- Enforced clinician access so trend data is only visible with patient-level full-report sharing; report-only sharing remains denied.
- Fixed report creation to preserve provided `observed_at`, ensuring correct longitudinal ordering.
- Added/updated backend tests covering trend retrieval, singleton non-fabrication, date-like filtering, mixed-unit non-fabrication, and clinician full-access authorization.
- Verified `backend/tests/test_trends_api.py` passes
