### PR TITLE
Improve layman translation prompt

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -663,8 +663,23 @@ async def translate_summary(
 
     prompt = (
         f"Translate the following patient education summary from English into {language_label}. "
-        "Preserve headings, bullet symbols (- or numbered lists), paragraph spacing, and tone. "
-        "Return only the translated text with no commentary or transliteration.\n\nTEXT:\n"
+        "Your job is not only to translate words. Rewrite the summary so it is easy to understand "
+        "for a child, teen, or adult while keeping the medical meaning accurate.\n\n"
+        "Keep this exact structure, in this order. Translate the headings and body into the target language:\n"
+        "1. Big picture - 2 or 3 short sentences that explain the overall result calmly.\n"
+        "2. What stood out - 3 to 5 simple bullet points. Each bullet should name the result, say if it is "
+        "high, low, normal, or unclear, and explain why that matters in everyday words.\n"
+        "3. What it means in plain words - explain the medical terms using familiar language. If a term like "
+        "cholesterol, hemoglobin, glucose, kidney, liver, inflammation, or infection appears, define it briefly.\n"
+        "4. What to ask your clinician - 2 to 4 practical questions the patient can bring to a doctor or nurse.\n"
+        "5. Reminder - one short sentence saying this is educational only and not a diagnosis.\n\n"
+        "Rules:\n"
+        "- Use short sentences and simple words.\n"
+        "- Do not add new medical facts, diagnoses, causes, or treatment advice that are not supported by the text.\n"
+        "- Do not make the result sound scarier or safer than the source text.\n"
+        "- Do not include English unless the target language normally uses the medical term.\n"
+        "- Return only the translated, structured text with no commentary or transliteration.\n\n"
+        "TEXT:\n"
         f"{trimmed}"
     )
 

--- a/backend/tests/test_translate.py
+++ b/backend/tests/test_translate.py
@@ -1,4 +1,6 @@
 
+import asyncio
+
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -53,4 +55,39 @@ def test_translate_blank_text():
     client = TestClient(app)
     resp = client.post("/api/v1/translate", json={"text": "  \n\t  ", "target_language": "es"})
     assert resp.status_code == 400
+
+
+def test_translate_summary_prompt_requests_structured_layman_explanation(monkeypatch):
+    from app.services import llm as llm_module
+
+    captured: dict[str, str] = {}
+
+    async def stub_llm(prompt: str, timeout_s: float):  # type: ignore[override]
+        captured["prompt"] = prompt
+        return "Resumen traducido", {"usage": {"total_tokens": 12}}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_USE_RESPONSES", "1")
+    monkeypatch.setattr(llm_module, "_call_openai_responses", stub_llm)
+
+    translation, meta = asyncio.run(
+        llm_module.translate_summary(
+            "SUMMARY: Hemoglobin is low.\nKEY POINTS:\n- This can happen for many reasons.",
+            target_language="es",
+            language_label="Spanish",
+        )
+    )
+
+    assert translation == "Resumen traducido"
+    assert meta.get("ok") is True
+    prompt = captured["prompt"]
+    assert "Your job is not only to translate" in prompt
+    assert "easy to understand for a child, teen, or adult" in prompt
+    assert "Keep this exact structure" in prompt
+    assert "1. Big picture" in prompt
+    assert "2. What stood out" in prompt
+    assert "3. What it means in plain words" in prompt
+    assert "4. What to ask your clinician" in prompt
+    assert "5. Reminder" in prompt
+    assert "Do not add new medical facts" in prompt
 


### PR DESCRIPTION
## Summary
- Reworked the translation prompt so translated summaries are also rewritten into a clear layman-friendly structure.
- Requires translated output to use five reader-friendly sections: big picture, what stood out, plain-word meaning, clinician questions, and reminder.
- Added a backend regression test that captures the LLM prompt and verifies the structure and safety constraints stay in place.

## Why
The previous prompt only asked the model to translate while preserving headings and bullets. That could leave users with a translated version of a dense medical explanation, which is still hard to understand. This change asks the model to keep medical meaning accurate while presenting the result in short, structured language that a child, teen, or adult can follow.

## Safety boundaries
- Do not add unsupported diagnoses, causes, treatment advice, or new medical facts.
- Do not make results sound scarier or safer than the source text.
- Keep the educational-only reminder in the translated output.

## Validation
- `python -m pytest backend\tests\test_translate.py -q`
- `python -m ruff check backend\app\services\llm.py backend\tests\test_translate.py`